### PR TITLE
feat: support customized kafka key for sink

### DIFF
--- a/docs/credentials-management/manifests/avro-producer-pipeline.yaml
+++ b/docs/credentials-management/manifests/avro-producer-pipeline.yaml
@@ -28,7 +28,7 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/docs/sink/avro/avro-sink.md
+++ b/docs/sink/avro/avro-sink.md
@@ -101,3 +101,7 @@ application on Numaflow. The way you specify the sink specification stays the sa
 
 In the example, the `producer.properties` contains the credentials. Please
 see [credentials management](../../credentials-management/protecting-credentials.md) to protect your credentials.
+
+### Custom Message Keys
+
+By default, the sink generates a UUID for each message key. To specify a custom key, include a datum key prefixed with `KAFKA_KEY:`. The remaining string after the prefix will be used as the Kafka message key. If no `KAFKA_KEY:` prefix is found, a UUID is generated automatically.

--- a/docs/sink/avro/manifests/avro-producer-pipeline.yaml
+++ b/docs/sink/avro/manifests/avro-producer-pipeline.yaml
@@ -28,7 +28,7 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/docs/sink/json/json-sink.md
+++ b/docs/sink/json/json-sink.md
@@ -99,3 +99,7 @@ application on Numaflow. The way you specify the sink specification stays the sa
 
 In the example, the `producer.properties` contains the credentials. Please
 see [credentials management](../../credentials-management/protecting-credentials.md) to protect your credentials.
+
+### Custom Message Keys
+
+By default, the sink generates a UUID for each message key. To specify a custom key, include a datum key prefixed with `KAFKA_KEY:`. The remaining string after the prefix will be used as the Kafka message key. If no `KAFKA_KEY:` prefix is found, a UUID is generated automatically.

--- a/docs/sink/json/manifests/json-producer-pipeline.yaml
+++ b/docs/sink/json/manifests/json-producer-pipeline.yaml
@@ -28,7 +28,7 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
+++ b/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
@@ -28,7 +28,7 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/docs/sink/no-schema/no-schema-sink.md
+++ b/docs/sink/no-schema/no-schema-sink.md
@@ -65,3 +65,7 @@ application on Numaflow. The way you specify the sink specification stays the sa
 
 In the example, the `producer.properties` contains the credentials. Please
 see [credentials management](../../credentials-management/protecting-credentials.md) to protect your credentials.
+
+### Custom Message Keys
+
+By default, the sink generates a UUID for each message key. To specify a custom key, include a datum key prefixed with `KAFKA_KEY:`. The remaining string after the prefix will be used as the Kafka message key. If no `KAFKA_KEY:` prefix is found, a UUID is generated automatically.

--- a/docs/source/avro/manifests/avro-consumer-pipeline.yaml
+++ b/docs/source/avro/manifests/avro-consumer-pipeline.yaml
@@ -20,7 +20,7 @@ spec:
       source:
         udsource:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
+++ b/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
@@ -20,7 +20,7 @@ spec:
       source:
         udsource:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.0
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.1
             args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
             imagePullPolicy: Always
             volumeMounts:

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
                             </container>
                             <to>
                                 <image>
-                                    numaproj-contrib/${project.artifactId}:v0.5.0
+                                    numaproj-contrib/${project.artifactId}:v0.5.1
                                 </image>
                             </to>
                         </configuration>

--- a/src/main/java/io/numaproj/kafka/common/CommonUtils.java
+++ b/src/main/java/io/numaproj/kafka/common/CommonUtils.java
@@ -3,6 +3,8 @@ package io.numaproj.kafka.common;
 /** Class holding common utility functions */
 public class CommonUtils {
 
+  private static final String KAFKA_KEY_PREFIX = "KAFKA_KEY:";
+
   /**
    * Generate a key for maps holding topic partition offsets
    *
@@ -12,5 +14,24 @@ public class CommonUtils {
    */
   public static String getTopicPartitionKey(String topic, int partition) {
     return topic + ":" + partition;
+  }
+
+  /**
+   * Extract Kafka message key from datum keys. If a key prefixed with "KAFKA_KEY:" is found,
+   * returns the remaining string after the prefix. Otherwise returns null.
+   *
+   * @param keys - array of keys from the datum
+   * @return the Kafka key if found, null otherwise
+   */
+  public static String extractKafkaKey(String[] keys) {
+    if (keys == null || keys.length == 0) {
+      return null;
+    }
+    for (String key : keys) {
+      if (key != null && key.startsWith(KAFKA_KEY_PREFIX)) {
+        return key.substring(KAFKA_KEY_PREFIX.length());
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/io/numaproj/kafka/producer/KafkaAvroSinker.java
+++ b/src/main/java/io/numaproj/kafka/producer/KafkaAvroSinker.java
@@ -1,5 +1,6 @@
 package io.numaproj.kafka.producer;
 
+import io.numaproj.kafka.common.CommonUtils;
 import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.kafka.schema.Registry;
 import io.numaproj.numaflow.sinker.*;
@@ -86,7 +87,10 @@ public class KafkaAvroSinker extends BaseKafkaSinker<GenericRecord> {
         break;
       }
 
-      String key = UUID.randomUUID().toString();
+      String key = CommonUtils.extractKafkaKey(datum.getKeys());
+      if (key == null) {
+        key = UUID.randomUUID().toString();
+      }
       String msg = new String(datum.getValue());
       log.trace("Processing message with id: {}, payload: {}", datum.getId(), msg);
 

--- a/src/main/java/io/numaproj/kafka/producer/KafkaByteArraySinker.java
+++ b/src/main/java/io/numaproj/kafka/producer/KafkaByteArraySinker.java
@@ -1,5 +1,6 @@
 package io.numaproj.kafka.producer;
 
+import io.numaproj.kafka.common.CommonUtils;
 import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.numaflow.sinker.*;
 import java.util.HashMap;
@@ -60,7 +61,10 @@ public class KafkaByteArraySinker extends BaseKafkaSinker<byte[]> {
       if (datum == null) {
         break;
       }
-      String key = UUID.randomUUID().toString();
+      String key = CommonUtils.extractKafkaKey(datum.getKeys());
+      if (key == null) {
+        key = UUID.randomUUID().toString();
+      }
       String msg = new String(datum.getValue());
       log.trace("Processing message with id: {}, payload: {}", datum.getId(), msg);
 

--- a/src/main/java/io/numaproj/kafka/producer/KafkaJsonSinker.java
+++ b/src/main/java/io/numaproj/kafka/producer/KafkaJsonSinker.java
@@ -1,5 +1,6 @@
 package io.numaproj.kafka.producer;
 
+import io.numaproj.kafka.common.CommonUtils;
 import io.numaproj.kafka.common.JsonValidator;
 import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.kafka.schema.Registry;
@@ -86,7 +87,10 @@ public class KafkaJsonSinker extends BaseKafkaSinker<byte[]> {
       if (datum == null) {
         break;
       }
-      String key = UUID.randomUUID().toString();
+      String key = CommonUtils.extractKafkaKey(datum.getKeys());
+      if (key == null) {
+        key = UUID.randomUUID().toString();
+      }
       String msg = new String(datum.getValue());
       log.trace("Processing message with id: {}, payload: {}", datum.getId(), msg);
 

--- a/src/test/java/io/numaproj/kafka/common/CommonUtilsTest.java
+++ b/src/test/java/io/numaproj/kafka/common/CommonUtilsTest.java
@@ -1,6 +1,7 @@
 package io.numaproj.kafka.common;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 
@@ -13,5 +14,67 @@ public class CommonUtilsTest {
     String expected = "test-topic:0";
     String actual = CommonUtils.getTopicPartitionKey(topic, partition);
     assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testExtractKafkaKey_withPrefix() {
+    String[] keys = {"KAFKA_KEY:my-custom-key"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("my-custom-key", result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_withPrefixAndOtherKeys() {
+    String[] keys = {"other-key", "KAFKA_KEY:my-custom-key", "another-key"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("my-custom-key", result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_withMultiplePrefixKeys_returnsFirstMatch() {
+    String[] keys = {"KAFKA_KEY:first-key", "KAFKA_KEY:second-key"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("first-key", result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_withoutPrefix() {
+    String[] keys = {"other-key", "another-key"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertNull(result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_caseSensitive() {
+    String[] keys = {"kafka_key:lowercase", "KAFKA_KEY:uppercase"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("uppercase", result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_nullKeys() {
+    String result = CommonUtils.extractKafkaKey(null);
+    assertNull(result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_emptyKeys() {
+    String[] keys = {};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertNull(result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_withNullInKeys() {
+    String[] keys = {null, "KAFKA_KEY:valid-key"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("valid-key", result);
+  }
+
+  @Test
+  public void testExtractKafkaKey_prefixOnly() {
+    String[] keys = {"KAFKA_KEY:"};
+    String result = CommonUtils.extractKafkaKey(keys);
+    assertEquals("", result);
   }
 }


### PR DESCRIPTION
Support user specified kafka key when publishing messages from sink, instead of always using UUID.