### PR TITLE
feat: EnvVar interpolation for properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
+# IntelliJ files
 .idea/*
 target/*
 .DS_Store
+
+# Zed files
+.classpath
+.factorypath
+.project
+.settings/

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,3 @@
-# IntelliJ files
 .idea/*
 target/*
 .DS_Store
-
-# Zed files
-.classpath
-.factorypath
-.project
-.settings/

--- a/docs/credentials-management/manifests/avro-producer-pipeline.yaml
+++ b/docs/credentials-management/manifests/avro-producer-pipeline.yaml
@@ -29,11 +29,7 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--producer.properties.path=/conf/producer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/credentials-management/manifests/avro-producer-pipeline.yaml
+++ b/docs/credentials-management/manifests/avro-producer-pipeline.yaml
@@ -28,8 +28,12 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--producer.properties.path=/conf/producer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/avro/manifests/avro-producer-pipeline.yaml
+++ b/docs/sink/avro/manifests/avro-producer-pipeline.yaml
@@ -29,11 +29,7 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--producer.properties.path=/conf/producer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/avro/manifests/avro-producer-pipeline.yaml
+++ b/docs/sink/avro/manifests/avro-producer-pipeline.yaml
@@ -28,8 +28,12 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--producer.properties.path=/conf/producer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/json/manifests/json-producer-pipeline.yaml
+++ b/docs/sink/json/manifests/json-producer-pipeline.yaml
@@ -29,11 +29,7 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--producer.properties.path=/conf/producer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/json/manifests/json-producer-pipeline.yaml
+++ b/docs/sink/json/manifests/json-producer-pipeline.yaml
@@ -28,8 +28,12 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--producer.properties.path=/conf/producer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
+++ b/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
@@ -29,11 +29,7 @@ spec:
         udsink:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--producer.properties.path=/conf/producer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
+++ b/docs/sink/no-schema/manifests/raw-producer-pipeline.yaml
@@ -28,8 +28,12 @@ spec:
       sink:
         udsink:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--producer.properties.path=/conf/producer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--producer.properties.path=/conf/producer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume

--- a/docs/source/avro/avro-source.md
+++ b/docs/source/avro/avro-source.md
@@ -76,6 +76,8 @@ Use the example [ConfigMap](manifests/avro-consumer-config.yaml) to configure th
 * `user.configuration` is the user configuration for the source vertex.
     * `topicName` is the Kafka topic name to read data from.
     * `schemaType` is set to `avro` to indicate that Avro schema is used to de-serialize the data.
+* You can interpolate environment variables in `consumer.properties` values using `${ENV_VAR}` (for example, to set
+  `group.instance.id=my-instance-${NUMAFLOW_REPLICA}` for static membership).
 
 Deploy the ConfigMap to the Kubernetes cluster.
 

--- a/docs/source/avro/manifests/avro-consumer-pipeline.yaml
+++ b/docs/source/avro/manifests/avro-consumer-pipeline.yaml
@@ -20,8 +20,12 @@ spec:
       source:
         udsource:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--consumer.properties.path=/conf/consumer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume
@@ -31,8 +35,7 @@ spec:
         min: 1
         max: 1
       sink:
-        log:
-          { }
+        log: {}
   edges:
     - from: in
       to: sink

--- a/docs/source/avro/manifests/avro-consumer-pipeline.yaml
+++ b/docs/source/avro/manifests/avro-consumer-pipeline.yaml
@@ -21,11 +21,7 @@ spec:
         udsource:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--consumer.properties.path=/conf/consumer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume
@@ -35,7 +31,8 @@ spec:
         min: 1
         max: 1
       sink:
-        log: {}
+        log:
+          { }
   edges:
     - from: in
       to: sink

--- a/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
+++ b/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
@@ -20,8 +20,12 @@ spec:
       source:
         udsource:
           container:
-            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.4
-            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
+            args:
+              [
+                "--spring.config.location=file:/conf/user.configuration.yaml",
+                "--consumer.properties.path=/conf/consumer.properties",
+              ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume
@@ -31,8 +35,7 @@ spec:
         min: 1
         max: 1
       sink:
-        log:
-          { }
+        log: {}
   edges:
     - from: in
       to: sink

--- a/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
+++ b/docs/source/non-avro/manifests/raw-consumer-pipeline.yaml
@@ -21,11 +21,7 @@ spec:
         udsource:
           container:
             image: quay.io/numaio/numaflow-java/kafka-java:v0.5.5
-            args:
-              [
-                "--spring.config.location=file:/conf/user.configuration.yaml",
-                "--consumer.properties.path=/conf/consumer.properties",
-              ]
+            args: [ "--spring.config.location=file:/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties" ]
             imagePullPolicy: Always
             volumeMounts:
               - name: kafka-config-volume
@@ -35,7 +31,8 @@ spec:
         min: 1
         max: 1
       sink:
-        log: {}
+        log:
+          { }
   edges:
     - from: in
       to: sink

--- a/docs/source/non-avro/non-avro-source.md
+++ b/docs/source/non-avro/non-avro-source.md
@@ -46,6 +46,8 @@ Use the example [ConfigMap](manifests/raw-consumer-config.yaml) to configure the
     * `topicName` is the Kafka topic name to read data from.
     * `schemaType` is set to `raw` to indicate that there is no schema registered for the topic. (You can also set the
       `schemaType` to `json` if the topic has a JSON schema registered).
+* You can interpolate environment variables in `consumer.properties` values using `${ENV_VAR}` (for example, to set
+  `group.instance.id=my-instance-${NUMAFLOW_REPLICA}` for static membership).
 
 Deploy the ConfigMap to the Kubernetes cluster.
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,30 +1,33 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8" ?>
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.5</version>
-        <relativePath/> <!-- lookup parent from repository -->
+        <relativePath /> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.numaproj.kafka</groupId>
     <artifactId>kafka-java</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>kafka-java</name>
     <description>Numaflow user-defined Kafka source and sink</description>
-    <url/>
+    <url />
     <licenses>
-        <license/>
+        <license />
     </licenses>
     <developers>
-        <developer/>
+        <developer />
     </developers>
     <scm>
-        <connection/>
-        <developerConnection/>
-        <tag/>
-        <url/>
+        <connection />
+        <developerConnection />
+        <tag />
+        <url />
     </scm>
     <properties>
         <java.version>21</java.version>
@@ -124,7 +127,7 @@
                             </container>
                             <to>
                                 <image>
-                                    numaproj-contrib/${project.artifactId}:v0.5.4
+                                    numaproj-contrib/${project.artifactId}:v0.5.5
                                 </image>
                             </to>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1,33 +1,30 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
->
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>3.4.5</version>
-        <relativePath /> <!-- lookup parent from repository -->
+        <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>io.numaproj.kafka</groupId>
     <artifactId>kafka-java</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>kafka-java</name>
     <description>Numaflow user-defined Kafka source and sink</description>
-    <url />
+    <url/>
     <licenses>
-        <license />
+        <license/>
     </licenses>
     <developers>
-        <developer />
+        <developer/>
     </developers>
     <scm>
-        <connection />
-        <developerConnection />
-        <tag />
-        <url />
+        <connection/>
+        <developerConnection/>
+        <tag/>
+        <url/>
     </scm>
     <properties>
         <java.version>21</java.version>

--- a/src/main/java/io/numaproj/kafka/common/EnvVarInterpolator.java
+++ b/src/main/java/io/numaproj/kafka/common/EnvVarInterpolator.java
@@ -1,0 +1,77 @@
+package io.numaproj.kafka.common;
+
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Expands ${ENV_VAR} placeholders in Java {@link Properties} values.
+ *
+ * <p>Behavior:
+ *
+ * <ul>
+ *   <li>Only expands placeholders in the form {@code ${VARNAME}}
+ *   <li>If an env var is missing, the placeholder is left unchanged
+ * </ul>
+ */
+@Slf4j
+public final class EnvVarInterpolator {
+
+  private static final Pattern ENV_PLACEHOLDER =
+      Pattern.compile("\\$\\{([A-Za-z_][A-Za-z0-9_]*)\\}");
+
+  private EnvVarInterpolator() {}
+
+  /** Interpolate using {@link System#getenv()}. */
+  public static void interpolate(Properties props) {
+    interpolate(props, System.getenv());
+  }
+
+  /** Interpolate using provided env map (useful for tests). */
+  public static void interpolate(Properties props, Map<String, String> env) {
+    if (props == null || props.isEmpty()) {
+      return;
+    }
+    if (env == null || env.isEmpty()) {
+      // Still do a pass to keep behavior consistent (placeholders remain unchanged).
+      env = Map.of();
+    }
+
+    for (String name : props.stringPropertyNames()) {
+      String raw = props.getProperty(name);
+      if (raw == null || raw.isEmpty()) {
+        continue;
+      }
+      String expanded = expand(raw, env);
+      if (!raw.equals(expanded)) {
+        props.setProperty(name, expanded);
+        log.debug("Interpolated property key='{}'", name);
+      }
+    }
+  }
+
+  private static String expand(String value, Map<String, String> env) {
+    Matcher matcher = ENV_PLACEHOLDER.matcher(value);
+    if (!matcher.find()) {
+      return value;
+    }
+
+    matcher.reset();
+    StringBuffer sb = new StringBuffer();
+    while (matcher.find()) {
+      String varName = matcher.group(1);
+      String envVal = env.get(varName);
+      if (envVal == null) {
+        // Leave placeholder unchanged.
+        matcher.appendReplacement(sb, Matcher.quoteReplacement(matcher.group(0)));
+      } else {
+        matcher.appendReplacement(sb, Matcher.quoteReplacement(envVal));
+      }
+    }
+    matcher.appendTail(sb);
+    return sb.toString();
+  }
+}
+

--- a/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
+++ b/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
@@ -1,5 +1,6 @@
 package io.numaproj.kafka.config;
 
+import io.numaproj.kafka.common.EnvVarInterpolator;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,146 +26,201 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "consumer.properties.path")
 public class ConsumerConfig {
 
-  @Value("${consumer.properties.path:NA}")
-  private String consumerPropertiesFilePath;
+    @Value("${consumer.properties.path:NA}")
+    private String consumerPropertiesFilePath;
 
-  // package-private constructor. this is for unit test only.
-  ConsumerConfig(@Value("${consumer.properties.path:NA}") String consumerPropertiesFilePath) {
-    this.consumerPropertiesFilePath = consumerPropertiesFilePath;
-  }
-
-  /**
-   * Provides the consumer group ID from consumer.properties file. This is the single source of
-   * truth for group.id configuration.
-   */
-  @Bean
-  public String consumerGroupId() throws IOException {
-    Properties props = new Properties();
-    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-    props.load(is);
-    is.close();
-
-    var groupId =
-        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
-    if (groupId == null || StringUtils.isBlank((String) groupId)) {
-      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
+    // package-private constructor. this is for unit test only.
+    ConsumerConfig(
+        @Value(
+            "${consumer.properties.path:NA}"
+        ) String consumerPropertiesFilePath
+    ) {
+        this.consumerPropertiesFilePath = consumerPropertiesFilePath;
     }
-    log.info("Consumer group ID from consumer.properties: {}", groupId);
-    return (String) groupId;
-  }
 
-  // Kafka Avro consumer client
-  @Bean
-  @ConditionalOnProperty(name = "schemaType", havingValue = "avro")
-  public KafkaConsumer<String, GenericRecord> kafkaAvroConsumer() throws IOException {
-    log.info(
-        "Instantiating the Kafka Avro consumer from the consumer properties file: {}",
-        this.consumerPropertiesFilePath);
-    Properties props = new Properties();
-    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-    props.load(is);
-    is.close();
-    // disable auto commit, numaflow data forwarder takes care of committing offsets
-    if (props.getProperty(
-                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-            != null
-        && Boolean.parseBoolean(
+    /**
+     * Provides the consumer group ID from consumer.properties file. This is the single source of
+     * truth for group.id configuration.
+     */
+    @Bean
+    public String consumerGroupId() throws IOException {
+        Properties props = new Properties();
+        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+        props.load(is);
+        is.close();
+        EnvVarInterpolator.interpolate(props);
+
+        var groupId = props.getOrDefault(
+            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
+            null
+        );
+        if (groupId == null || StringUtils.isBlank((String) groupId)) {
+            throw new IllegalArgumentException(
+                "group.id is mandatory for Kafka consumer"
+            );
+        }
+        log.info("Consumer group ID from consumer.properties: {}", groupId);
+        return (String) groupId;
+    }
+
+    // Kafka Avro consumer client
+    @Bean
+    @ConditionalOnProperty(name = "schemaType", havingValue = "avro")
+    public KafkaConsumer<String, GenericRecord> kafkaAvroConsumer()
+        throws IOException {
+        log.info(
+            "Instantiating the Kafka Avro consumer from the consumer properties file: {}",
+            this.consumerPropertiesFilePath
+        );
+        Properties props = new Properties();
+        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+        props.load(is);
+        is.close();
+        EnvVarInterpolator.interpolate(props);
+        // disable auto commit, numaflow data forwarder takes care of committing offsets
+        if (
             props.getProperty(
-                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
-      log.info("Overwriting enable.auto.commit to false.");
-    }
-    props.put(org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    // ensure consumer group id is present
-    var groupId =
-        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
-    if (groupId == null || StringUtils.isBlank((String) groupId)) {
-      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
+                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+                ) !=
+                null &&
+            Boolean.parseBoolean(
+                props.getProperty(
+                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+                )
+            )
+        ) {
+            log.info("Overwriting enable.auto.commit to false.");
+        }
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            "false"
+        );
+        // ensure consumer group id is present
+        var groupId = props.getOrDefault(
+            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
+            null
+        );
+        if (groupId == null || StringUtils.isBlank((String) groupId)) {
+            throw new IllegalArgumentException(
+                "group.id is mandatory for Kafka consumer"
+            );
+        }
+
+        // override the deserializer
+        // TODO - warning message if user sets a different deserializer
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringDeserializer"
+        );
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            "io.confluent.kafka.serializers.KafkaAvroDeserializer"
+        );
+
+        // set credential properties from environment variable
+        String credentialProperties = System.getenv(
+            "KAFKA_CREDENTIAL_PROPERTIES"
+        );
+        if (credentialProperties != null && !credentialProperties.isEmpty()) {
+            StringReader sr = new StringReader(credentialProperties);
+            props.load(sr);
+            sr.close();
+            EnvVarInterpolator.interpolate(props);
+        }
+        return new KafkaConsumer<>(props);
     }
 
-    // override the deserializer
-    // TODO - warning message if user sets a different deserializer
-    props.put(
-        org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-        "org.apache.kafka.common.serialization.StringDeserializer");
-    props.put(
-        org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-        "io.confluent.kafka.serializers.KafkaAvroDeserializer");
-
-    // set credential properties from environment variable
-    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
-    if (credentialProperties != null && !credentialProperties.isEmpty()) {
-      StringReader sr = new StringReader(credentialProperties);
-      props.load(sr);
-      sr.close();
-    }
-    return new KafkaConsumer<>(props);
-  }
-
-  // Kafka byte array consumer client
-  @Bean
-  @ConditionalOnExpression("'${schemaType}'.equals('json') or '${schemaType}'.equals('raw')")
-  public KafkaConsumer<String, byte[]> kafkaByteArrayConsumer() throws IOException {
-    log.info(
-        "Instantiating the Kafka byte array consumer from the consumer properties file: {}",
-        this.consumerPropertiesFilePath);
-    Properties props = new Properties();
-    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-    props.load(is);
-    is.close();
-    // disable auto commit, numaflow data forwarder takes care of committing offsets
-    if (props.getProperty(
-                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
-            != null
-        && Boolean.parseBoolean(
+    // Kafka byte array consumer client
+    @Bean
+    @ConditionalOnExpression(
+        "'${schemaType}'.equals('json') or '${schemaType}'.equals('raw')"
+    )
+    public KafkaConsumer<String, byte[]> kafkaByteArrayConsumer()
+        throws IOException {
+        log.info(
+            "Instantiating the Kafka byte array consumer from the consumer properties file: {}",
+            this.consumerPropertiesFilePath
+        );
+        Properties props = new Properties();
+        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+        props.load(is);
+        is.close();
+        EnvVarInterpolator.interpolate(props);
+        // disable auto commit, numaflow data forwarder takes care of committing offsets
+        if (
             props.getProperty(
-                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
-      log.info("Overwriting enable.auto.commit to false.");
-    }
-    props.put(org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
-    // ensure consumer group id is present
-    var groupId =
-        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
-    if (groupId == null || StringUtils.isBlank((String) groupId)) {
-      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
+                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+                ) !=
+                null &&
+            Boolean.parseBoolean(
+                props.getProperty(
+                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
+                )
+            )
+        ) {
+            log.info("Overwriting enable.auto.commit to false.");
+        }
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+            "false"
+        );
+        // ensure consumer group id is present
+        var groupId = props.getOrDefault(
+            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
+            null
+        );
+        if (groupId == null || StringUtils.isBlank((String) groupId)) {
+            throw new IllegalArgumentException(
+                "group.id is mandatory for Kafka consumer"
+            );
+        }
+
+        // override the deserializer
+        // TODO - warning message if user sets a different deserializer
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.StringDeserializer"
+        );
+        props.put(
+            org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            "org.apache.kafka.common.serialization.ByteArrayDeserializer"
+        );
+
+        // set credential properties from environment variable
+        String credentialProperties = System.getenv(
+            "KAFKA_CREDENTIAL_PROPERTIES"
+        );
+        if (credentialProperties != null && !credentialProperties.isEmpty()) {
+            StringReader sr = new StringReader(credentialProperties);
+            props.load(sr);
+            sr.close();
+            EnvVarInterpolator.interpolate(props);
+        }
+        return new KafkaConsumer<>(props);
     }
 
-    // override the deserializer
-    // TODO - warning message if user sets a different deserializer
-    props.put(
-        org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-        "org.apache.kafka.common.serialization.StringDeserializer");
-    props.put(
-        org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
-
-    // set credential properties from environment variable
-    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
-    if (credentialProperties != null && !credentialProperties.isEmpty()) {
-      StringReader sr = new StringReader(credentialProperties);
-      props.load(sr);
-      sr.close();
+    // AdminClient is used to retrieve the number of pending messages.
+    // Currently, it shares the same properties file with Kafka consumer client.
+    // TODO - consider having a separate properties file for admin client.
+    // Admin client should be able to serve both consumer and producer,
+    // and it does not need all the properties that consumer client needs.
+    @Bean
+    public AdminClient kafkaAdminClient() throws IOException {
+        Properties props = new Properties();
+        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+        props.load(is);
+        is.close();
+        EnvVarInterpolator.interpolate(props);
+        // set credential properties from environment variable
+        String credentialProperties = System.getenv(
+            "KAFKA_CREDENTIAL_PROPERTIES"
+        );
+        if (credentialProperties != null && !credentialProperties.isEmpty()) {
+            StringReader sr = new StringReader(credentialProperties);
+            props.load(sr);
+            sr.close();
+            EnvVarInterpolator.interpolate(props);
+        }
+        return KafkaAdminClient.create(props);
     }
-    return new KafkaConsumer<>(props);
-  }
-
-  // AdminClient is used to retrieve the number of pending messages.
-  // Currently, it shares the same properties file with Kafka consumer client.
-  // TODO - consider having a separate properties file for admin client.
-  // Admin client should be able to serve both consumer and producer,
-  // and it does not need all the properties that consumer client needs.
-  @Bean
-  public AdminClient kafkaAdminClient() throws IOException {
-    Properties props = new Properties();
-    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-    props.load(is);
-    is.close();
-    // set credential properties from environment variable
-    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
-    if (credentialProperties != null && !credentialProperties.isEmpty()) {
-      StringReader sr = new StringReader(credentialProperties);
-      props.load(sr);
-      sr.close();
-    }
-    return KafkaAdminClient.create(props);
-  }
 }

--- a/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
+++ b/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
@@ -26,201 +26,153 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnProperty(name = "consumer.properties.path")
 public class ConsumerConfig {
 
-    @Value("${consumer.properties.path:NA}")
-    private String consumerPropertiesFilePath;
+  @Value("${consumer.properties.path:NA}")
+  private String consumerPropertiesFilePath;
 
-    // package-private constructor. this is for unit test only.
-    ConsumerConfig(
-        @Value(
-            "${consumer.properties.path:NA}"
-        ) String consumerPropertiesFilePath
-    ) {
-        this.consumerPropertiesFilePath = consumerPropertiesFilePath;
+  // package-private constructor. this is for unit test only.
+  ConsumerConfig(@Value("${consumer.properties.path:NA}") String consumerPropertiesFilePath) {
+    this.consumerPropertiesFilePath = consumerPropertiesFilePath;
+  }
+
+  /**
+   * Provides the consumer group ID from consumer.properties file. This is the single source of
+   * truth for group.id configuration.
+   */
+  @Bean
+  public String consumerGroupId() throws IOException {
+    Properties props = new Properties();
+    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+    props.load(is);
+    is.close();
+    EnvVarInterpolator.interpolate(props);
+
+    var groupId =
+        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
+    if (groupId == null || StringUtils.isBlank((String) groupId)) {
+      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
     }
+    log.info("Consumer group ID from consumer.properties: {}", groupId);
+    return (String) groupId;
+  }
 
-    /**
-     * Provides the consumer group ID from consumer.properties file. This is the single source of
-     * truth for group.id configuration.
-     */
-    @Bean
-    public String consumerGroupId() throws IOException {
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-        props.load(is);
-        is.close();
-        EnvVarInterpolator.interpolate(props);
-
-        var groupId = props.getOrDefault(
-            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
-            null
-        );
-        if (groupId == null || StringUtils.isBlank((String) groupId)) {
-            throw new IllegalArgumentException(
-                "group.id is mandatory for Kafka consumer"
-            );
-        }
-        log.info("Consumer group ID from consumer.properties: {}", groupId);
-        return (String) groupId;
-    }
-
-    // Kafka Avro consumer client
-    @Bean
-    @ConditionalOnProperty(name = "schemaType", havingValue = "avro")
-    public KafkaConsumer<String, GenericRecord> kafkaAvroConsumer()
-        throws IOException {
-        log.info(
-            "Instantiating the Kafka Avro consumer from the consumer properties file: {}",
-            this.consumerPropertiesFilePath
-        );
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-        props.load(is);
-        is.close();
-        EnvVarInterpolator.interpolate(props);
-        // disable auto commit, numaflow data forwarder takes care of committing offsets
-        if (
+  // Kafka Avro consumer client
+  @Bean
+  @ConditionalOnProperty(name = "schemaType", havingValue = "avro")
+  public KafkaConsumer<String, GenericRecord> kafkaAvroConsumer() throws IOException {
+    log.info(
+        "Instantiating the Kafka Avro consumer from the consumer properties file: {}",
+        this.consumerPropertiesFilePath);
+    Properties props = new Properties();
+    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+    props.load(is);
+    is.close();
+    EnvVarInterpolator.interpolate(props);
+    // disable auto commit, numaflow data forwarder takes care of committing offsets
+    if (props.getProperty(
+                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+            != null
+        && Boolean.parseBoolean(
             props.getProperty(
-                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
-                ) !=
-                null &&
-            Boolean.parseBoolean(
-                props.getProperty(
-                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
-                )
-            )
-        ) {
-            log.info("Overwriting enable.auto.commit to false.");
-        }
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
-            "false"
-        );
-        // ensure consumer group id is present
-        var groupId = props.getOrDefault(
-            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
-            null
-        );
-        if (groupId == null || StringUtils.isBlank((String) groupId)) {
-            throw new IllegalArgumentException(
-                "group.id is mandatory for Kafka consumer"
-            );
-        }
-
-        // override the deserializer
-        // TODO - warning message if user sets a different deserializer
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-            "org.apache.kafka.common.serialization.StringDeserializer"
-        );
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-            "io.confluent.kafka.serializers.KafkaAvroDeserializer"
-        );
-
-        // set credential properties from environment variable
-        String credentialProperties = System.getenv(
-            "KAFKA_CREDENTIAL_PROPERTIES"
-        );
-        if (credentialProperties != null && !credentialProperties.isEmpty()) {
-            StringReader sr = new StringReader(credentialProperties);
-            props.load(sr);
-            sr.close();
-            EnvVarInterpolator.interpolate(props);
-        }
-        return new KafkaConsumer<>(props);
+                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
+      log.info("Overwriting enable.auto.commit to false.");
+    }
+    props.put(org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    // ensure consumer group id is present
+    var groupId =
+        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
+    if (groupId == null || StringUtils.isBlank((String) groupId)) {
+      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
     }
 
-    // Kafka byte array consumer client
-    @Bean
-    @ConditionalOnExpression(
-        "'${schemaType}'.equals('json') or '${schemaType}'.equals('raw')"
-    )
-    public KafkaConsumer<String, byte[]> kafkaByteArrayConsumer()
-        throws IOException {
-        log.info(
-            "Instantiating the Kafka byte array consumer from the consumer properties file: {}",
-            this.consumerPropertiesFilePath
-        );
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-        props.load(is);
-        is.close();
-        EnvVarInterpolator.interpolate(props);
-        // disable auto commit, numaflow data forwarder takes care of committing offsets
-        if (
+    // override the deserializer
+    // TODO - warning message if user sets a different deserializer
+    props.put(
+        org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringDeserializer");
+    props.put(
+        org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        "io.confluent.kafka.serializers.KafkaAvroDeserializer");
+
+    // set credential properties from environment variable
+    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
+    if (credentialProperties != null && !credentialProperties.isEmpty()) {
+      StringReader sr = new StringReader(credentialProperties);
+      props.load(sr);
+      sr.close();
+      EnvVarInterpolator.interpolate(props);
+    }
+    return new KafkaConsumer<>(props);
+  }
+
+  // Kafka byte array consumer client
+  @Bean
+  @ConditionalOnExpression("'${schemaType}'.equals('json') or '${schemaType}'.equals('raw')")
+  public KafkaConsumer<String, byte[]> kafkaByteArrayConsumer() throws IOException {
+    log.info(
+        "Instantiating the Kafka byte array consumer from the consumer properties file: {}",
+        this.consumerPropertiesFilePath);
+    Properties props = new Properties();
+    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+    props.load(is);
+    is.close();
+    EnvVarInterpolator.interpolate(props);
+    // disable auto commit, numaflow data forwarder takes care of committing offsets
+    if (props.getProperty(
+                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+            != null
+        && Boolean.parseBoolean(
             props.getProperty(
-                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
-                ) !=
-                null &&
-            Boolean.parseBoolean(
-                props.getProperty(
-                    org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG
-                )
-            )
-        ) {
-            log.info("Overwriting enable.auto.commit to false.");
-        }
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
-            "false"
-        );
-        // ensure consumer group id is present
-        var groupId = props.getOrDefault(
-            org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG,
-            null
-        );
-        if (groupId == null || StringUtils.isBlank((String) groupId)) {
-            throw new IllegalArgumentException(
-                "group.id is mandatory for Kafka consumer"
-            );
-        }
-
-        // override the deserializer
-        // TODO - warning message if user sets a different deserializer
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-            "org.apache.kafka.common.serialization.StringDeserializer"
-        );
-        props.put(
-            org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-            "org.apache.kafka.common.serialization.ByteArrayDeserializer"
-        );
-
-        // set credential properties from environment variable
-        String credentialProperties = System.getenv(
-            "KAFKA_CREDENTIAL_PROPERTIES"
-        );
-        if (credentialProperties != null && !credentialProperties.isEmpty()) {
-            StringReader sr = new StringReader(credentialProperties);
-            props.load(sr);
-            sr.close();
-            EnvVarInterpolator.interpolate(props);
-        }
-        return new KafkaConsumer<>(props);
+                org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
+      log.info("Overwriting enable.auto.commit to false.");
+    }
+    props.put(org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+    // ensure consumer group id is present
+    var groupId =
+        props.getOrDefault(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, null);
+    if (groupId == null || StringUtils.isBlank((String) groupId)) {
+      throw new IllegalArgumentException("group.id is mandatory for Kafka consumer");
     }
 
-    // AdminClient is used to retrieve the number of pending messages.
-    // Currently, it shares the same properties file with Kafka consumer client.
-    // TODO - consider having a separate properties file for admin client.
-    // Admin client should be able to serve both consumer and producer,
-    // and it does not need all the properties that consumer client needs.
-    @Bean
-    public AdminClient kafkaAdminClient() throws IOException {
-        Properties props = new Properties();
-        InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
-        props.load(is);
-        is.close();
-        EnvVarInterpolator.interpolate(props);
-        // set credential properties from environment variable
-        String credentialProperties = System.getenv(
-            "KAFKA_CREDENTIAL_PROPERTIES"
-        );
-        if (credentialProperties != null && !credentialProperties.isEmpty()) {
-            StringReader sr = new StringReader(credentialProperties);
-            props.load(sr);
-            sr.close();
-            EnvVarInterpolator.interpolate(props);
-        }
-        return KafkaAdminClient.create(props);
+    // override the deserializer
+    // TODO - warning message if user sets a different deserializer
+    props.put(
+        org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.StringDeserializer");
+    props.put(
+        org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+        "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+
+    // set credential properties from environment variable
+    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
+    if (credentialProperties != null && !credentialProperties.isEmpty()) {
+      StringReader sr = new StringReader(credentialProperties);
+      props.load(sr);
+      sr.close();
+      EnvVarInterpolator.interpolate(props);
     }
+    return new KafkaConsumer<>(props);
+  }
+
+  // AdminClient is used to retrieve the number of pending messages.
+  // Currently, it shares the same properties file with Kafka consumer client.
+  // TODO - consider having a separate properties file for admin client.
+  // Admin client should be able to serve both consumer and producer,
+  // and it does not need all the properties that consumer client needs.
+  @Bean
+  public AdminClient kafkaAdminClient() throws IOException {
+    Properties props = new Properties();
+    InputStream is = new FileInputStream(this.consumerPropertiesFilePath);
+    props.load(is);
+    is.close();
+    EnvVarInterpolator.interpolate(props);
+    // set credential properties from environment variable
+    String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
+    if (credentialProperties != null && !credentialProperties.isEmpty()) {
+      StringReader sr = new StringReader(credentialProperties);
+      props.load(sr);
+      sr.close();
+      EnvVarInterpolator.interpolate(props);
+    }
+    return KafkaAdminClient.create(props);
+  }
 }

--- a/src/main/java/io/numaproj/kafka/config/ProducerConfig.java
+++ b/src/main/java/io/numaproj/kafka/config/ProducerConfig.java
@@ -2,6 +2,7 @@ package io.numaproj.kafka.config;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.numaproj.kafka.common.EnvVarInterpolator;
 import io.numaproj.kafka.schema.ConfluentRegistry;
 import io.numaproj.kafka.schema.Registry;
 import java.io.FileInputStream;
@@ -47,6 +48,7 @@ public class ProducerConfig {
     Properties props = new Properties();
     InputStream is = new FileInputStream(this.producerPropertiesFilePath);
     props.load(is);
+    EnvVarInterpolator.interpolate(props);
     // override the serializer
     // TODO - warning message if user sets a different serializer
     props.put(
@@ -64,6 +66,7 @@ public class ProducerConfig {
       StringReader sr = new StringReader(credentialProperties);
       props.load(sr);
       sr.close();
+      EnvVarInterpolator.interpolate(props);
     }
     is.close();
     return new KafkaProducer<>(props);
@@ -79,6 +82,7 @@ public class ProducerConfig {
     Properties props = new Properties();
     InputStream is = new FileInputStream(this.producerPropertiesFilePath);
     props.load(is);
+    EnvVarInterpolator.interpolate(props);
     // override the serializer
     // TODO - warning message if user sets a different serializer
     props.put(
@@ -96,6 +100,7 @@ public class ProducerConfig {
       StringReader sr = new StringReader(credentialProperties);
       props.load(sr);
       sr.close();
+      EnvVarInterpolator.interpolate(props);
     }
     is.close();
     return new KafkaProducer<>(props);
@@ -109,6 +114,7 @@ public class ProducerConfig {
     Properties props = new Properties();
     InputStream is = new FileInputStream(this.producerPropertiesFilePath);
     props.load(is);
+    EnvVarInterpolator.interpolate(props);
 
     // set credential properties from environment variable
     String credentialProperties = System.getenv("KAFKA_CREDENTIAL_PROPERTIES");
@@ -116,6 +122,7 @@ public class ProducerConfig {
       StringReader sr = new StringReader(credentialProperties);
       props.load(sr);
       sr.close();
+      EnvVarInterpolator.interpolate(props);
     }
     String schemaRegistryUrl = props.getProperty("schema.registry.url");
     int identityMapCapacity =

--- a/src/test/java/io/numaproj/kafka/common/EnvVarInterpolatorTest.java
+++ b/src/test/java/io/numaproj/kafka/common/EnvVarInterpolatorTest.java
@@ -1,0 +1,44 @@
+package io.numaproj.kafka.common;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+
+public class EnvVarInterpolatorTest {
+
+  @Test
+  public void interpolate_replacesKnownEnvVarPlaceholders() {
+    Properties props = new Properties();
+    props.setProperty("group.instance.id", "my-instance-${NUMAFLOW_REPLICA}");
+    props.setProperty("bootstrap.servers", "${BOOTSTRAP}");
+
+    EnvVarInterpolator.interpolate(
+        props, Map.of("NUMAFLOW_REPLICA", "2", "BOOTSTRAP", "broker:9092"));
+
+    assertEquals("my-instance-2", props.getProperty("group.instance.id"));
+    assertEquals("broker:9092", props.getProperty("bootstrap.servers"));
+  }
+
+  @Test
+  public void interpolate_leavesUnknownEnvVarPlaceholdersUnchanged() {
+    Properties props = new Properties();
+    props.setProperty("group.instance.id", "my-instance-${MISSING}");
+
+    EnvVarInterpolator.interpolate(props, Map.of("NUMAFLOW_REPLICA", "2"));
+
+    assertEquals("my-instance-${MISSING}", props.getProperty("group.instance.id"));
+  }
+
+  @Test
+  public void interpolate_supportsMultiplePlaceholdersInSingleValue() {
+    Properties props = new Properties();
+    props.setProperty("x", "${A}-${B}-${A}");
+
+    EnvVarInterpolator.interpolate(props, Map.of("A", "foo", "B", "bar"));
+
+    assertEquals("foo-bar-foo", props.getProperty("x"));
+  }
+}
+


### PR DESCRIPTION
Closes #33 

* Added ${ENV_VAR} interpolation for values in consumer.properties and producer.properties.
* Applied it after loading the files and after overlaying KAFKA_CREDENTIAL_PROPERTIES.
* Added tests for the interpolator and a brief docs note (e.g. group.instance.id=...${NUMAFLOW_REPLICA}).