### PR TITLE
chore: add an e2e test to CI

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,7 +37,7 @@ jobs:
           kubectl create namespace numaflow-system
           kubectl apply -n numaflow-system -f https://github.com/numaproj/numaflow/releases/download/v1.7.5/install.yaml
           kubectl apply -f https://github.com/numaproj/numaflow/releases/download/v1.7.5/validating-webhook-install.yaml
-          kubectl rollout status deployment/numaflow-controller -n numaflow-system --timeout=120s
+          kubectl wait --for=condition=Available deployment --all -n numaflow-system --timeout=120s
 
       - name: Create InterStepBufferService
         run: |

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,103 @@
+name: E2E Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Build image
+        run: mvn package -DskipTests
+
+      - name: Set up k3d
+        uses: AbsaOSS/k3d-action@v2
+        with:
+          cluster-name: test-cluster
+          args: --agents 1
+
+      - name: Load image into k3d
+        run: k3d image import quay.io/numaio/numaflow-java/kafka-java:$(mvn help:evaluate -Dexpression=image.tag -q -DforceStdout | tr -d '\n') -c test-cluster
+        # Avoids needing to push to a registry — image is loaded directly into the cluster
+
+      - name: Install Numaflow
+        run: |
+          kubectl create namespace numaflow-system
+          kubectl apply -n numaflow-system -f https://github.com/numaproj/numaflow/releases/download/v1.7.5/install.yaml
+          kubectl apply -f https://github.com/numaproj/numaflow/releases/download/v1.7.5/validating-webhook-install.yaml
+          kubectl rollout status deployment/numaflow-controller -n numaflow-system --timeout=120s
+
+      - name: Create InterStepBufferService
+        run: |
+          kubectl apply -f - <<EOF
+          apiVersion: numaflow.numaproj.io/v1alpha1
+          kind: InterStepBufferService
+          metadata:
+            name: default
+            namespace: default
+          spec:
+            jetstream:
+              version: latest
+          EOF
+          kubectl wait --for=jsonpath='{.status.phase}'=Running interstepbufferservice/default -n default --timeout=120s
+
+      - name: Deploy Kafka
+        run: |
+          kubectl create namespace kafka
+          kubectl apply -f test/kafka.yaml
+          kubectl rollout status deployment/kafka -n kafka --timeout=120s
+
+      - name: Create test topic
+        run: |
+          KAFKA_POD=$(kubectl get pod -n kafka -l app=kafka -o jsonpath='{.items[0].metadata.name}')
+          kubectl exec -n kafka $KAFKA_POD -- /opt/kafka/bin/kafka-topics.sh \
+            --create --topic test-raw \
+            --bootstrap-server localhost:9092 \
+            --partitions 1 --replication-factor 1
+
+      - name: Deploy pipeline
+        run: |
+          # Use the locally built image tag, not the quay.io remote
+          IMAGE_TAG=$(mvn help:evaluate -Dexpression=image.tag -q -DforceStdout | tr -d '\n')
+          sed "s|quay.io/numaio/numaflow-java/kafka-java:.*|quay.io/numaio/numaflow-java/kafka-java:$IMAGE_TAG|g" test/pipeline.yaml \
+            | kubectl apply -f -
+          kubectl apply -f test/pipeline-config.yaml
+          kubectl wait --for=condition=Ready pod \
+            -l numaflow.numaproj.io/pipeline-name=test-kafka-pipeline \
+            -n default --timeout=120s
+
+      - name: Produce test messages
+        run: |
+          KAFKA_POD=$(kubectl get pod -n kafka -l app=kafka -o jsonpath='{.items[0].metadata.name}')
+          kubectl exec -n kafka $KAFKA_POD -- bash -c \
+            'echo -e "hello numaflow 1\nhello numaflow 2\nhello numaflow 3" | /opt/kafka/bin/kafka-console-producer.sh --topic test-raw --bootstrap-server localhost:9092'
+
+      - name: Assert messages received by sink
+        run: |
+          SINK_POD=$(kubectl get pod -n default -l numaflow.numaproj.io/vertex-name=sink -o jsonpath='{.items[0].metadata.name}')
+          for i in $(seq 1 30); do
+            LOGS=$(kubectl logs $SINK_POD -n default --all-containers=true 2>/dev/null)
+            if echo "$LOGS" | grep -q "hello numaflow 1" && \
+               echo "$LOGS" | grep -q "hello numaflow 2" && \
+               echo "$LOGS" | grep -q "hello numaflow 3"; then
+              echo "All 3 messages received by sink"
+              exit 0
+            fi
+            echo "Waiting for messages... attempt $i/30"
+            sleep 5
+          done
+          echo "ERROR: Messages not received in sink after 150s"
+          kubectl logs $SINK_POD -n default --all-containers=true | tail -50
+          exit 1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -52,6 +52,7 @@ jobs:
               version: latest
           EOF
           kubectl wait --for=jsonpath='{.status.phase}'=Running interstepbufferservice/default -n default --timeout=120s
+          kubectl wait --for=condition=Ready pod -l numaflow.numaproj.io/isbsvc-name=default -n default --timeout=120s
 
       - name: Deploy Kafka
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <lombok.version>1.18.32</lombok.version>
         <!-- Single Netty BOM: numaflow-java uses native HTTP/transport on 4.2.x alongside grpc-netty -->
         <netty.version>4.2.13.Final</netty.version>
+        <image.tag>v0.5.6</image.tag>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -275,7 +276,7 @@
                             </container>
                             <to>
                                 <image>
-                                    quay.io/numaio/numaflow-java/${project.artifactId}:v0.5.6
+                                    quay.io/numaio/numaflow-java/${project.artifactId}:${image.tag}
                                 </image>
                             </to>
                         </configuration>

--- a/test/kafka.yaml
+++ b/test/kafka.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka
+  template:
+    metadata:
+      labels:
+        app: kafka
+    spec:
+      containers:
+        - name: kafka
+          image: apache/kafka:3.9.0
+          ports:
+            - containerPort: 9092
+          env:
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_PROCESS_ROLES
+              value: "broker,controller"
+            - name: KAFKA_LISTENERS
+              value: "PLAINTEXT://0.0.0.0:9092,CONTROLLER://localhost:9093"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "PLAINTEXT://kafka.kafka.svc.cluster.local:9092"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: CLUSTER_ID
+              value: "MkU3OEVBNTcwNTJENDM2Qk"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka
+  namespace: kafka
+spec:
+  selector:
+    app: kafka
+  ports:
+    - port: 9092
+      targetPort: 9092

--- a/test/pipeline-config.yaml
+++ b/test/pipeline-config.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-consumer-config
+  namespace: default
+data:
+  consumer.properties: |
+    bootstrap.servers=kafka.kafka.svc.cluster.local:9092
+    security.protocol=PLAINTEXT
+    client.dns.lookup=use_all_dns_ips
+    session.timeout.ms=45000
+    retries=0
+    group.id=test-group
+  user.configuration: |
+    topicName: test-raw
+    schemaType: raw

--- a/test/pipeline.yaml
+++ b/test/pipeline.yaml
@@ -1,0 +1,38 @@
+apiVersion: numaflow.numaproj.io/v1alpha1
+kind: Pipeline
+metadata:
+  name: test-kafka-pipeline
+  namespace: default
+spec:
+  vertices:
+    - name: in
+      volumes:
+        - name: kafka-config-volume
+          configMap:
+            name: test-consumer-config
+            items:
+              - key: user.configuration
+                path: user.configuration.yaml
+              - key: consumer.properties
+                path: consumer.properties
+      scale:
+        min: 1
+        max: 1
+      source:
+        udsource:
+          container:
+            image: quay.io/numaio/numaflow-java/kafka-java:v0.5.6
+            args: ["--config=/conf/user.configuration.yaml", "--consumer.properties.path=/conf/consumer.properties"]
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: kafka-config-volume
+                mountPath: /conf
+    - name: sink
+      scale:
+        min: 1
+        max: 1
+      sink:
+        log: {}
+  edges:
+    - from: in
+      to: sink


### PR DESCRIPTION
Add e2e tests to CI, verifying udsource works by starting a local kafka cluster, sending messages and verifying log sink.