### PR TITLE
feat(source): add onError=skip to drop and count skipped messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ example [here](docs/sink/json/json-sink.md).
 
 Use Case 6: Write data to Kafka with no schema. See an example [here](docs/sink/no-schema/no-schema-sink.md).
 
+### Metrics
+
+The source exposes Prometheus metrics over HTTP. See [source metrics](docs/metrics/source-metrics.md)
+for the metric list, scrape configuration, and recommended alerts.
+
 ## Upgrading from a Spring Boot version?
 
 If you are upgrading from a Spring Boot-based release, update the **image tag** and make the following changes to your

--- a/docs/metrics/source-metrics.md
+++ b/docs/metrics/source-metrics.md
@@ -1,0 +1,94 @@
+# Source metrics
+
+### Introduction
+
+The Kafka source exposes its own [Prometheus](https://prometheus.io/) metrics over HTTP. This is
+necessary because `numaflow-java` provides no metrics API and no Prometheus client is present on the
+classpath transitively - so without this endpoint, the source would be entirely unobservable from a
+metrics standpoint. Numaflow's user-defined `Container` type has a `ports` field added expressly to
+support this
+([numaflow#2135](https://github.com/numaproj/numaflow/pull/2135): *"Expose containerPort for user
+defined containers so that it can be used for prometheus metrics scraping configuration."*).
+
+This page is vendor-neutral: it covers scraping the endpoint, not shipping the samples to any
+particular backend (CloudWatch, AMP, etc).
+
+### Metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `kafka_java_source_read_errors_total` | counter | `stage` = `decode`\|`convert`, `reason` = `bad_data`\|`unknown`, `action` = `skipped`\|`failed` | A record failed to be read. One counter covers both `onError` policies, so a single dashboard shows skip volume *and* the failure that killed the pod. |
+| `kafka_java_source_records_dropped_total` | counter | `reason` = `null_value` | A record was dropped without being an error (currently only Kafka tombstones). |
+
+All label values come from closed enums, so cardinality is bounded at compile time.
+
+### Recommended alert
+
+```promql
+increase(kafka_java_source_read_errors_total{reason="unknown"}[5m]) > 0
+```
+
+`reason="unknown"` means records were dropped for a reason not attributable to their own bytes - e.g.
+a key-management or schema-registry outage. This is the interim signal for the follow-up work that
+will retry or circuit-break on such failures instead of merely counting them; see
+[the onError documentation](../source/envelope-encryption/decrypting-source.md#failure-behavior).
+
+### Endpoint
+
+- Path: `/metrics`
+- Default port: `9091` (chosen to avoid Numaflow's reserved `2469`/`2470`/`4327` ports)
+- Overridable via the `KAFKA_JAVA_METRICS_PORT` environment variable; set to `0` to disable the
+  endpoint entirely.
+
+```bash
+curl -s localhost:9091/metrics | grep kafka_java_source
+```
+
+### Scraping
+
+**A `ServiceMonitor` cannot reach this port.** The `<vertex>-headless` Service that Numaflow creates has
+its port map hardcoded to `metrics` (2469) and `runtime` (2470) in the controller, so a custom port
+cannot be added to it. Use a **PodMonitor** or pod annotations instead.
+
+#### PodMonitor
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: kafka-java-source
+spec:
+  selector:
+    matchLabels:
+      numaflow.numaproj.io/component: vertex # adjust to match your vertex pods
+  podMetricsEndpoints:
+    - port: metrics-source # must match the named container port below
+      path: /metrics
+```
+
+The `udsource.container.ports` field must name the port so the `PodMonitor` can select it by name:
+
+```yaml
+udsource:
+  container:
+    ports:
+      - name: metrics-source
+        containerPort: 9091
+```
+
+This `Container` type is shared between `Pipeline` and `MonoVertex` specs.
+
+#### Annotation fallback
+
+If you scrape via `prometheus.io/*` pod annotations instead of the Prometheus Operator, the
+annotations live in a different place depending on the deployment shape:
+
+- **Pipeline**: `spec.vertices[].metadata.annotations`
+- **MonoVertex**: `spec.metadata.annotations`
+
+```yaml
+annotations:
+  prometheus.io/scrape: "true"
+  prometheus.io/port: "9091"
+  prometheus.io/path: "/metrics"
+```

--- a/docs/source/avro-glue/avro-glue-source.md
+++ b/docs/source/avro-glue/avro-glue-source.md
@@ -109,6 +109,15 @@ Once the pipeline is running you should see JSON-encoded Avro records in the sin
 Payload -  {"Name":"John","Age":30}
 ```
 
+### Handling records that fail to be read
+
+By default, a record that fails to be read (a malformed schema-registry frame, an undecodable Avro
+payload, ...) crashes the vertex. Setting `onError: skip` in `user.configuration` - a
+`user.configuration` key, not a `consumer.properties` one, and **source-only** (the sink ignores it) -
+drops such a record and counts it instead. See
+[failure behavior](../envelope-encryption/decrypting-source.md#failure-behavior) for the full
+semantics and the recommended alert.
+
 ### Assuming an IAM role
 
 If the pod's base credentials do not have direct Glue access, add `assumeRoleArn` to `consumer.properties`:

--- a/docs/source/avro-glue/manifests/avro-glue-consumer-config.yaml
+++ b/docs/source/avro-glue/manifests/avro-glue-consumer-config.yaml
@@ -37,3 +37,6 @@ data:
   user.configuration: |
     topicName: [placeholder]
     schemaType: avro
+    # Optional: onError: fail (default) crashes the vertex on a record that fails to be read;
+    # skip drops it and counts it (kafka_java_source_read_errors_total). Source-only.
+    # onError: fail

--- a/docs/source/avro/avro-source.md
+++ b/docs/source/avro/avro-source.md
@@ -76,6 +76,8 @@ Use the example [ConfigMap](manifests/avro-consumer-config.yaml) to configure th
 * `user.configuration` is the user configuration for the source vertex.
     * `topicName` is the Kafka topic name to read data from.
     * `schemaType` is set to `avro` to indicate that Avro schema is used to de-serialize the data.
+    * `onError` (optional, source-only) is `fail` (default) or `skip`; see
+      [failure behavior](../envelope-encryption/decrypting-source.md#failure-behavior).
 * You can interpolate environment variables in `consumer.properties` values using `${ENV_VAR}` (for example, to set
   `group.instance.id=my-instance-${NUMAFLOW_REPLICA}` for static membership).
 

--- a/docs/source/avro/manifests/avro-consumer-config.yaml
+++ b/docs/source/avro/manifests/avro-consumer-config.yaml
@@ -26,3 +26,6 @@ data:
   user.configuration: |
     topicName: numagen-avro
     schemaType: avro
+    # Optional: onError: fail (default) crashes the vertex on a record that fails to be read;
+    # skip drops it and counts it (kafka_java_source_read_errors_total). Source-only.
+    # onError: fail

--- a/docs/source/envelope-encryption/decrypting-source.md
+++ b/docs/source/envelope-encryption/decrypting-source.md
@@ -88,12 +88,47 @@ built-in log sink.
 
 ### Failure behavior
 
-The source **fails fast** (logs a clear error and exits, so the pod restarts) on any unrecoverable
-condition: a malformed key ARN at startup; or, per message, a value that is not a valid envelope, an
-unsupported `alg`, a KMS `Decrypt` failure (including ciphertext wrapped under a different key), or an
-authentication-tag failure (tampering / wrong key). A poison or tampered message will therefore
-crash-loop the vertex until its offset is advanced or the message is removed. Plaintext keys and
-decrypted payloads are never logged.
+By default, the source **fails fast** (logs a clear error and exits, so the pod restarts) on any
+unrecoverable condition: a malformed key ARN at startup; or, per message, a value that is not a valid
+envelope, an unsupported `alg`, a KMS `Decrypt` failure (including ciphertext wrapped under a different
+key), or an authentication-tag failure (tampering / wrong key). A poison or tampered message will
+therefore crash-loop the vertex until its offset is advanced or the message is removed. Plaintext keys
+and decrypted payloads are never logged.
+
+#### `onError: skip`
+
+Setting `onError: skip` in `user.configuration` (source-only - the sink ignores it) changes this: a
+record that fails to be read is dropped and counted instead of crashing the vertex. A `WARN` log
+identifies the dropped record by `topic`/`partition`/`offset` only - never the record itself - and
+`kafka_java_source_read_errors_total{stage="decode", ..., action="skipped"}` is incremented. See
+[source metrics](../../metrics/source-metrics.md) for the full metric and an alerting query.
+
+The record is **lost** - there is no dead-letter queue yet (`BadRecordSink` is the seam a future one
+will use).
+
+Today, `skip` drops **every** decode failure, including one **not** attributable to the record's own
+bytes - for example a KMS throttle, an expired credential, or a Glue/Confluent schema-registry outage.
+This is deliberate for now: reliably distinguishing "this record's bytes are corrupt" from "the
+environment is unavailable" cannot be done cheaply across AWS SDK and schema-registry exception
+taxonomies (see the design notes in the source code). The failure is still classified as a metric
+label - `reason="bad_data"` vs. `reason="unknown"` - so the risk is measurable even though it is not
+yet gated:
+
+```promql
+increase(kafka_java_source_read_errors_total{reason="unknown"}[5m]) > 0
+```
+
+An alert firing on this query means records were dropped for a reason not attributable to their own
+bytes - most likely an incident (KMS or schema-registry outage, expired credentials) discarding good
+records rather than bad ones. A follow-up will retry or circuit-break such failures instead of skipping
+them.
+
+**Startup failures always fail fast**, regardless of `onError`: a malformed key ARN, for instance, is
+a configuration error, not a per-record one, and `onError` never applies to it.
+
+**Kafka authentication failures are not per-record either.** A `SaslAuthenticationException` (e.g. from
+MSK IAM auth) fails the consumer as a whole, not a single record, and correctly kills the vertex under
+any `onError` setting rather than being skipped.
 
 > **Producer responsibility — nonce uniqueness.** AES-256-GCM is only secure if the producer never
 > reuses a nonce under the same DEK. Reuse is catastrophic: it exposes the XOR of the affected

--- a/docs/source/envelope-encryption/manifests/encrypted-consumer-config.yaml
+++ b/docs/source/envelope-encryption/manifests/encrypted-consumer-config.yaml
@@ -36,3 +36,7 @@ data:
   user.configuration: |
     topicName: [placeholder]
     schemaType: avro
+    # Optional: onError: fail (default) crashes the vertex on a record that fails to be read
+    # (including a decryption failure); skip drops it and counts it
+    # (kafka_java_source_read_errors_total). Source-only.
+    # onError: fail

--- a/docs/source/non-avro/manifests/raw-consumer-config.yaml
+++ b/docs/source/non-avro/manifests/raw-consumer-config.yaml
@@ -21,3 +21,6 @@ data:
   user.configuration: |
     topicName: numagen-raw
     schemaType: raw
+    # Optional: onError: fail (default) crashes the vertex on a record that fails to be read;
+    # skip drops it and counts it (kafka_java_source_read_errors_total). Source-only.
+    # onError: fail

--- a/docs/source/non-avro/non-avro-source.md
+++ b/docs/source/non-avro/non-avro-source.md
@@ -46,6 +46,8 @@ Use the example [ConfigMap](manifests/raw-consumer-config.yaml) to configure the
     * `topicName` is the Kafka topic name to read data from.
     * `schemaType` is set to `raw` to indicate that there is no schema registered for the topic. (You can also set the
       `schemaType` to `json` if the topic has a JSON schema registered).
+    * `onError` (optional, source-only) is `fail` (default) or `skip`; see
+      [failure behavior](../envelope-encryption/decrypting-source.md#failure-behavior).
 * You can interpolate environment variables in `consumer.properties` values using `${ENV_VAR}` (for example, to set
   `group.instance.id=my-instance-${NUMAFLOW_REPLICA}` for static membership).
 

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,25 @@
             <version>${lombok.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- Prometheus metrics exposition over HTTP. exposition-formats is excluded: it carries a
+             shaded protobuf for the deprecated protobuf exposition format; exposition-textformats
+             remains and is all Prometheus scraping needs. Zero third-party transitives otherwise. -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-core</artifactId>
+            <version>1.8.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.prometheus</groupId>
+                    <artifactId>prometheus-metrics-exposition-formats</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>prometheus-metrics-exporter-httpserver</artifactId>
+            <version>1.8.0</version>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -222,6 +241,11 @@
                         --add-opens java.base/java.io=ALL-UNNAMED
                         --add-opens java.base/java.nio=ALL-UNNAMED
                     </argLine>
+                    <!-- Disable the metrics HTTP server during unit tests: KafkaApplicationTest calls
+                         main() several times in the same JVM, and a fixed port cannot be rebound. -->
+                    <environmentVariables>
+                        <KAFKA_JAVA_METRICS_PORT>0</KAFKA_JAVA_METRICS_PORT>
+                    </environmentVariables>
                 </configuration>
             </plugin>
             <plugin>
@@ -275,6 +299,9 @@
                                 <mainClass>
                                     io.numaproj.kafka.KafkaApplication
                                 </mainClass>
+                                <ports>
+                                    <port>9091</port>
+                                </ports>
                                 <jvmFlags>
                                     <jvmFlag>-XX:+UnlockExperimentalVMOptions</jvmFlag>
                                     <jvmFlag>-XX:MaxRAMPercentage=70</jvmFlag>

--- a/src/main/java/io/numaproj/kafka/KafkaApplication.java
+++ b/src/main/java/io/numaproj/kafka/KafkaApplication.java
@@ -11,8 +11,10 @@ import io.numaproj.kafka.consumer.KafkaSourcer;
 import io.numaproj.kafka.format.AvroFormat;
 import io.numaproj.kafka.format.ByteArrayFormat;
 import io.numaproj.kafka.format.JsonFormat;
+import io.numaproj.kafka.metrics.MetricsServer;
 import io.numaproj.kafka.producer.KafkaSinker;
 import io.numaproj.kafka.schema.Registry;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -63,6 +65,11 @@ public class KafkaApplication {
 
     UserConfig userConfig = buildUserConfig(argMap);
     log.info("UserConfig: {}", userConfig);
+
+    MetricsServer metricsServer = MetricsServer.start(PrometheusRegistry.defaultRegistry);
+    if (metricsServer != null) {
+      Runtime.getRuntime().addShutdownHook(new Thread(metricsServer::stop));
+    }
 
     switch (handler.toLowerCase()) {
       case HANDLER_CONSUMER -> startConsumer(argMap, userConfig);

--- a/src/main/java/io/numaproj/kafka/KafkaApplication.java
+++ b/src/main/java/io/numaproj/kafka/KafkaApplication.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.numaproj.kafka.config.ConsumerConfig;
+import io.numaproj.kafka.config.OnError;
 import io.numaproj.kafka.config.ProducerConfig;
 import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.kafka.consumer.Admin;
@@ -12,6 +13,8 @@ import io.numaproj.kafka.format.AvroFormat;
 import io.numaproj.kafka.format.ByteArrayFormat;
 import io.numaproj.kafka.format.JsonFormat;
 import io.numaproj.kafka.metrics.MetricsServer;
+import io.numaproj.kafka.metrics.PrometheusSourceMetrics;
+import io.numaproj.kafka.metrics.SourceMetrics;
 import io.numaproj.kafka.producer.KafkaSinker;
 import io.numaproj.kafka.schema.Registry;
 import io.prometheus.metrics.model.registry.PrometheusRegistry;
@@ -36,6 +39,7 @@ public class KafkaApplication {
   private static final String KEY_SCHEMA_TYPE = "schemaType";
   private static final String KEY_SCHEMA_SUBJECT = "schemaSubject";
   private static final String KEY_SCHEMA_VERSION = "schemaVersion";
+  private static final String KEY_ON_ERROR = "onError";
 
   private static final String HANDLER_CONSUMER = "consumer";
   private static final String HANDLER_PRODUCER = "producer";
@@ -92,15 +96,16 @@ public class KafkaApplication {
     String groupId = consumerConfig.consumerGroupId();
     var adminClient = consumerConfig.kafkaAdminClient();
     Admin admin = new Admin(userConfig, groupId, adminClient);
+    SourceMetrics metrics = new PrometheusSourceMetrics(PrometheusRegistry.defaultRegistry);
 
     if (SCHEMA_TYPE_AVRO.equals(userConfig.getSchemaType())) {
       new KafkaSourcer<GenericRecord>(
-              userConfig, admin, AvroFormat.forSource(), consumerConfig::kafkaAvroConsumer)
+              userConfig, admin, AvroFormat.forSource(), consumerConfig::kafkaAvroConsumer, metrics)
           .startConsumer();
     } else {
       // json or raw: values are forwarded downstream as-is
       new KafkaSourcer<byte[]>(
-              userConfig, admin, new ByteArrayFormat(), consumerConfig::kafkaByteArrayConsumer)
+              userConfig, admin, new ByteArrayFormat(), consumerConfig::kafkaByteArrayConsumer, metrics)
           .startConsumer();
     }
   }
@@ -202,6 +207,7 @@ public class KafkaApplication {
         .schemaType(schemaType)
         .schemaSubject(schemaSubject)
         .schemaVersion(schemaVersion)
+        .onError(OnError.from(argMap.get(KEY_ON_ERROR)))
         .build();
   }
 

--- a/src/main/java/io/numaproj/kafka/common/BadRecordException.java
+++ b/src/main/java/io/numaproj/kafka/common/BadRecordException.java
@@ -1,0 +1,22 @@
+package io.numaproj.kafka.common;
+
+/**
+ * A failure attributable to the record's own bytes, as opposed to the environment (e.g. a
+ * key-management or schema-registry outage).
+ *
+ * <p>This is the one marker the core read path relies on to classify a failure. Provider adapters
+ * (AWS KMS, AWS Glue, Confluent, ...) translate their own record-attributable errors into this type
+ * or a subclass of it; the classifier then only needs to ask whether one appears anywhere in a
+ * failure's cause chain. This keeps cloud- and vendor-specific exception taxonomies out of the
+ * cloud-agnostic consumer package.
+ */
+public class BadRecordException extends RuntimeException {
+
+  public BadRecordException(String message) {
+    super(message);
+  }
+
+  public BadRecordException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
+++ b/src/main/java/io/numaproj/kafka/config/ConsumerConfig.java
@@ -1,8 +1,11 @@
 package io.numaproj.kafka.config;
 
 import com.amazonaws.services.schemaregistry.deserializers.GlueSchemaRegistryKafkaDeserializer;
+import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
+import com.amazonaws.services.schemaregistry.exception.GlueSchemaRegistryIncompatibleDataException;
 import com.google.common.annotations.VisibleForTesting;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.numaproj.kafka.common.BadRecordException;
 import io.numaproj.kafka.common.EnvVarInterpolator;
 import io.numaproj.kafka.encryption.DecryptingDeserializer;
 import io.numaproj.kafka.encryption.EnvelopeDecryptionFactory;
@@ -20,9 +23,11 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import software.amazon.awssdk.core.exception.SdkException;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
@@ -125,7 +130,8 @@ public class ConsumerConfig {
 
     @SuppressWarnings("unchecked")
     Deserializer<GenericRecord> valueDeserializer =
-        (Deserializer<GenericRecord>) (Deserializer<?>) avroDeserializer;
+        wrapWithBadRecordTranslation(
+            (Deserializer<GenericRecord>) (Deserializer<?>) avroDeserializer);
 
     // strip kafka-java-managed keys as the last step before instantiating the client
     stripManagedProps(props);
@@ -227,5 +233,59 @@ public class ConsumerConfig {
   static <T> Deserializer<T> wrapWithDecryption(
       Deserializer<T> deserializer, PayloadDecryptor decryptor) {
     return decryptor == null ? deserializer : new DecryptingDeserializer<>(deserializer, decryptor);
+  }
+
+  /**
+   * Wraps a schema-registry value deserializer so its record-attributable decode failures surface
+   * as {@link BadRecordException}, while environment failures (registry unreachable, access denied,
+   * throttled) propagate untranslated. This is the one place in the codebase that already imports
+   * Glue's exception types, so it owns the mapping and keeps the consumer package cloud-agnostic.
+   *
+   * <p>Verified against {@code software.amazon.glue:schema-registry-serde:1.1.27}:
+   * {@code GlueSchemaRegistryIncompatibleDataException} (a malformed header/compression byte or
+   * otherwise undecodable payload) is always record-attributable. A plain {@code
+   * AWSSchemaRegistryException} is also thrown for Glue API failures, so it is translated only when
+   * its cause chain contains no {@link SdkException}. Confluent's deserializer throws Kafka's own
+   * {@link SerializationException}, which is translated unconditionally - Confluent's Avro
+   * deserializer does not distinguish registry-unavailable from malformed-data via this type.
+   */
+  @VisibleForTesting
+  static <T> Deserializer<T> wrapWithBadRecordTranslation(Deserializer<T> deserializer) {
+    return new Deserializer<T>() {
+      @Override
+      public void configure(Map<String, ?> configs, boolean isKey) {
+        deserializer.configure(configs, isKey);
+      }
+
+      @Override
+      public T deserialize(String topic, byte[] data) {
+        try {
+          return deserializer.deserialize(topic, data);
+        } catch (GlueSchemaRegistryIncompatibleDataException e) {
+          throw new BadRecordException("Failed to deserialize the schema registry record", e);
+        } catch (AWSSchemaRegistryException e) {
+          if (containsSdkException(e)) {
+            throw e;
+          }
+          throw new BadRecordException("Failed to deserialize the schema registry record", e);
+        } catch (SerializationException e) {
+          throw new BadRecordException("Failed to deserialize the record", e);
+        }
+      }
+
+      @Override
+      public void close() {
+        deserializer.close();
+      }
+    };
+  }
+
+  private static boolean containsSdkException(Throwable failure) {
+    for (Throwable t = failure; t != null; t = t.getCause()) {
+      if (t instanceof SdkException) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/io/numaproj/kafka/config/OnError.java
+++ b/src/main/java/io/numaproj/kafka/config/OnError.java
@@ -1,0 +1,34 @@
+package io.numaproj.kafka.config;
+
+import java.util.Locale;
+
+/**
+ * The source's behavior when a record fails to be read (either decoded or converted). A {@code
+ * user.configuration} key, source-only - see {@link UserConfig}.
+ */
+public enum OnError {
+  /** Propagate the failure so the vertex crashes visibly and diagnosably. The default. */
+  FAIL,
+  /** Drop the failing record, count it, and continue. See the source's metrics documentation. */
+  SKIP;
+
+  /**
+   * Parses the {@code onError} configuration value, case-insensitively.
+   *
+   * @param value the configured value; blank or {@code null} means {@link #FAIL}
+   * @return the parsed policy
+   * @throws IllegalArgumentException if {@code value} is non-blank and not a recognized policy -
+   *     rejecting a typo at startup rather than silently defaulting to {@link #FAIL}
+   */
+  public static OnError from(String value) {
+    if (value == null || value.isBlank()) {
+      return FAIL;
+    }
+    try {
+      return valueOf(value.trim().toUpperCase(Locale.ROOT));
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid onError value: '" + value + "'. Must be one of: fail, skip", e);
+    }
+  }
+}

--- a/src/main/java/io/numaproj/kafka/config/UserConfig.java
+++ b/src/main/java/io/numaproj/kafka/config/UserConfig.java
@@ -22,4 +22,8 @@ public class UserConfig {
   // optional schema subject and version if user wants to use a specific schema
   private String schemaSubject;
   private int schemaVersion;
+
+  // Source-only: how the source reacts to a record that fails to be read. UserConfig is shared with
+  // the sink, so a producer deployment setting this key is silently ignored.
+  @Builder.Default private OnError onError = OnError.FAIL;
 }

--- a/src/main/java/io/numaproj/kafka/consumer/BadRecordPolicy.java
+++ b/src/main/java/io/numaproj/kafka/consumer/BadRecordPolicy.java
@@ -1,0 +1,50 @@
+package io.numaproj.kafka.consumer;
+
+import io.numaproj.kafka.config.OnError;
+import io.numaproj.kafka.metrics.SourceMetrics;
+import io.numaproj.kafka.metrics.SourceMetrics.Action;
+import java.util.function.Supplier;
+
+/**
+ * The single place the {@code onError} policy is applied to a read failure: the failure is
+ * classified, the metric is incremented, and - if skipping - the drop is dispatched to the {@link
+ * BadRecordSink}.
+ */
+final class BadRecordPolicy {
+
+  private final OnError onError;
+  private final SourceMetrics metrics;
+  private final BadRecordSink sink;
+
+  BadRecordPolicy(OnError onError, SourceMetrics metrics, BadRecordSink sink) {
+    this.onError = onError;
+    this.metrics = metrics;
+    this.sink = sink;
+  }
+
+  /**
+   * @param where the record's coordinates, for logging and the (future) dead-letter sink
+   * @param stage where in the read path the failure was detected
+   * @param failure the failure to classify; classification reads the cause chain, so pass the
+   *     innermost cause available (e.g. {@code RecordDeserializationException.getCause()}, not the
+   *     wrapper itself)
+   * @param rawValue lazily supplies the record's bytes for a future dead-letter sink; never
+   *     evaluated by the current (logging-only) sink
+   * @return {@code true} if the record should be dropped; {@code false} if the caller must
+   *     propagate the failure
+   */
+  boolean shouldSkip(RecordLocation where, Stage stage, Throwable failure, Supplier<byte[]> rawValue) {
+    ReadErrorReason reason = ReadErrorReason.of(failure);
+    if (onError != OnError.SKIP) {
+      metrics.recordReadError(stage, reason, Action.FAILED);
+      return false;
+    }
+    // TODO - follow-up PR: environmental failures (key-management or schema-registry outage,
+    //  expired credentials, throttling) are skipped here like bad data. They should instead be
+    //  retried or pause the vertex, because skipping them discards good records. Until then,
+    //  reason=unknown on kafka_java_source_read_errors_total is the signal to alert on.
+    metrics.recordReadError(stage, reason, Action.SKIPPED);
+    sink.quarantine(new BadRecord(where, stage, reason, failure, rawValue));
+    return true;
+  }
+}

--- a/src/main/java/io/numaproj/kafka/consumer/BadRecordSink.java
+++ b/src/main/java/io/numaproj/kafka/consumer/BadRecordSink.java
@@ -1,0 +1,41 @@
+package io.numaproj.kafka.consumer;
+
+import java.util.function.Supplier;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The single integration point for what happens to a record dropped by {@link BadRecordPolicy}.
+ * Today the only implementation counts and logs; a future dead-letter sink plugs in here with no
+ * change to the read path.
+ */
+interface BadRecordSink {
+  void quarantine(BadRecord badRecord);
+}
+
+/**
+ * A record dropped by {@link BadRecordPolicy}.
+ *
+ * @param rawValue lazy so log-and-drop never materializes (or logs) the payload. Stage {@code
+ *     DECODE} failures carry the still-encrypted bytes off the wire; stage {@code CONVERT} failures
+ *     carry an already-decrypted value, so a future dead-letter sink must treat the two differently.
+ */
+record BadRecord(
+    RecordLocation location,
+    Stage stage,
+    ReadErrorReason reason,
+    Throwable failure,
+    Supplier<byte[]> rawValue) {}
+
+/** Logs the drop with the record's coordinates only - never the record itself. */
+@Slf4j
+final class LoggingBadRecordSink implements BadRecordSink {
+  @Override
+  public void quarantine(BadRecord badRecord) {
+    log.warn(
+        "Dropping bad record {} stage:{} reason:{}",
+        badRecord.location(),
+        badRecord.stage(),
+        badRecord.reason(),
+        badRecord.failure());
+  }
+}

--- a/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
+++ b/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
@@ -135,9 +135,16 @@ public class KafkaSourcer<V> extends Sourcer {
     try {
       payload = format.toPayload(consumerRecord.value());
     } catch (FormatException e) {
-      String errMsg = "Failed to convert the record to a payload: " + consumerRecord;
-      log.error(errMsg, e);
-      throw new RuntimeException(errMsg, e);
+      // Identify the record by coordinates only - never render the record itself (its value may be
+      // a decrypted GenericRecord whose toString() is the plaintext payload).
+      throw new RuntimeException(
+          "Failed to convert the record to a payload: topic:"
+              + consumerRecord.topic()
+              + " partition:"
+              + consumerRecord.partition()
+              + " offset:"
+              + consumerRecord.offset(),
+          e);
     }
     return new Message(
         payload,

--- a/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
+++ b/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
@@ -5,6 +5,7 @@ import io.numaproj.kafka.common.CommonUtils;
 import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.kafka.format.FormatException;
 import io.numaproj.kafka.format.KafkaFormat;
+import io.numaproj.kafka.metrics.SourceMetrics;
 import io.numaproj.numaflow.sourcer.*;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -37,6 +38,8 @@ public class KafkaSourcer<V> extends Sourcer {
   private final Admin admin;
   private final KafkaFormat<V> format;
   private final ConsumerFactory<V> consumerFactory;
+  private final SourceMetrics metrics;
+  private final BadRecordPolicy policy;
 
   // The worker and its thread are lazily initialized on the first read() call because the Numaflow
   // batch size (used to set max.poll.records) is not known until the first ReadRequest arrives.
@@ -52,10 +55,25 @@ public class KafkaSourcer<V> extends Sourcer {
       Admin admin,
       KafkaFormat<V> format,
       ConsumerFactory<V> consumerFactory) {
+    this(userConfig, admin, format, consumerFactory, SourceMetrics.NOOP);
+  }
+
+  public KafkaSourcer(
+      UserConfig userConfig,
+      Admin admin,
+      KafkaFormat<V> format,
+      ConsumerFactory<V> consumerFactory,
+      SourceMetrics metrics) {
     this.userConfig = userConfig;
     this.admin = admin;
     this.format = format;
     this.consumerFactory = consumerFactory;
+    this.metrics = metrics;
+    // Built once here (not per record) and shared by the worker (decode failures) and this class
+    // (convert failures), so onError is applied and counted identically at both read-path stages.
+    this.policy =
+        new BadRecordPolicy(
+            userConfig == null ? null : userConfig.getOnError(), metrics, new LoggingBadRecordSink());
   }
 
   public void startConsumer() throws Exception {
@@ -72,7 +90,7 @@ public class KafkaSourcer<V> extends Sourcer {
         "Initializing consumer worker with batchSize={} timeoutMs={}",
         batchSize,
         request.getTimeout().toMillis());
-    worker = new KafkaWorker<>(userConfig, consumerFactory.create(batchSize));
+    worker = new KafkaWorker<>(userConfig, consumerFactory.create(batchSize), policy, metrics);
     workerThread = new Thread(worker, "consumerWorkerThread");
     workerThread.start();
   }
@@ -108,13 +126,23 @@ public class KafkaSourcer<V> extends Sourcer {
     }
 
     int sent = 0;
-    for (ConsumerRecord<String, V> consumerRecord : consumerRecordList) {
-      if (consumerRecord == null) {
-        continue;
+    try {
+      for (ConsumerRecord<String, V> consumerRecord : consumerRecordList) {
+        if (consumerRecord == null) {
+          continue;
+        }
+        if (!forward(consumerRecord, observer)) {
+          // Dropped: deliberately NOT tracked. readTopicPartitionOffsetMap is the read/ack
+          // cross-check, and Numaflow can only ack what it received; the consumer position (what
+          // actually gets committed) is already past this record.
+          continue;
+        }
+        trackReadOffset(consumerRecord);
+        sent++;
       }
-      observer.send(toMessage(consumerRecord));
-      trackReadOffset(consumerRecord);
-      sent++;
+    } catch (RuntimeException e) {
+      kill(e);
+      return;
     }
     log.debug(
         "BatchRead summary: requested:{} sent:{} partitions:{} readTopicPartitionOffsetMap:{}",
@@ -124,28 +152,37 @@ public class KafkaSourcer<V> extends Sourcer {
         readTopicPartitionOffsetMap);
   }
 
-  private Message toMessage(ConsumerRecord<String, V> consumerRecord) {
+  /**
+   * Converts and sends a single record.
+   *
+   * @return {@code true} if the record was sent; {@code false} if it was dropped under {@code
+   *     onError: skip}
+   * @throws RuntimeException if conversion failed and the policy says to propagate it
+   */
+  private boolean forward(ConsumerRecord<String, V> consumerRecord, OutputObserver observer) {
+    byte[] payload;
+    try {
+      payload = format.toPayload(consumerRecord.value());
+    } catch (FormatException e) {
+      RecordLocation where = RecordLocation.of(consumerRecord);
+      // rawValue is never evaluated by the current (logging-only) sink; deliberately not wired to
+      // the decrypted value here, since a future dead-letter sink would otherwise write plaintext.
+      if (!policy.shouldSkip(where, Stage.CONVERT, e, () -> null)) {
+        throw new RuntimeException("Failed to convert the record to a payload: " + where, e);
+      }
+      return false;
+    }
+    observer.send(toMessage(consumerRecord, payload));
+    return true;
+  }
+
+  private static <V> Message toMessage(ConsumerRecord<String, V> consumerRecord, byte[] payload) {
     Map<String, String> kafkaHeaders = new HashMap<>();
     for (Header header : consumerRecord.headers()) {
       kafkaHeaders.put(header.key(), new String(header.value(), StandardCharsets.UTF_8));
     }
     // TODO - Do we need to add cluster ID to the offset value? For now this is good enough.
     String offsetValue = consumerRecord.topic() + ":" + consumerRecord.offset();
-    byte[] payload;
-    try {
-      payload = format.toPayload(consumerRecord.value());
-    } catch (FormatException e) {
-      // Identify the record by coordinates only - never render the record itself (its value may be
-      // a decrypted GenericRecord whose toString() is the plaintext payload).
-      throw new RuntimeException(
-          "Failed to convert the record to a payload: topic:"
-              + consumerRecord.topic()
-              + " partition:"
-              + consumerRecord.partition()
-              + " offset:"
-              + consumerRecord.offset(),
-          e);
-    }
     return new Message(
         payload,
         new Offset(offsetValue.getBytes(StandardCharsets.UTF_8), consumerRecord.partition()),

--- a/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
+++ b/src/main/java/io/numaproj/kafka/consumer/KafkaSourcer.java
@@ -96,7 +96,11 @@ public class KafkaSourcer<V> extends Sourcer {
     try {
       consumerRecordList = worker.poll(request.getTimeout().toMillis());
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       kill(new RuntimeException(e));
+      return;
+    } catch (RuntimeException e) {
+      kill(e);
       return;
     }
     if (consumerRecordList == null) {
@@ -175,7 +179,10 @@ public class KafkaSourcer<V> extends Sourcer {
     try {
       worker.commit();
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       kill(new RuntimeException(e));
+    } catch (RuntimeException e) {
+      kill(e);
     }
   }
 

--- a/src/main/java/io/numaproj/kafka/consumer/KafkaWorker.java
+++ b/src/main/java/io/numaproj/kafka/consumer/KafkaWorker.java
@@ -1,6 +1,9 @@
 package io.numaproj.kafka.consumer;
 
 import io.numaproj.kafka.config.UserConfig;
+import io.numaproj.kafka.metrics.SourceMetrics;
+import io.numaproj.kafka.metrics.SourceMetrics.DropReason;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -9,12 +12,14 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RecordDeserializationException;
 
 /**
  * Consumes messages from a Kafka topic and commits offsets on demand. All Kafka client access
@@ -31,6 +36,8 @@ public class KafkaWorker<V> implements Runnable {
 
   private final UserConfig userConfig;
   private final KafkaConsumer<String, V> consumer;
+  private final BadRecordPolicy policy;
+  private final SourceMetrics metrics;
 
   // A blocking queue used to hand tasks to the consumer thread. It ensures only one of the
   // tasks (POLL/COMMIT/SHUTDOWN) is performed at a time.
@@ -40,9 +47,15 @@ public class KafkaWorker<V> implements Runnable {
   // Records polled from Kafka; volatile to ensure visibility across threads.
   private volatile List<ConsumerRecord<String, V>> consumerRecordList;
 
-  public KafkaWorker(UserConfig userConfig, KafkaConsumer<String, V> consumer) {
+  public KafkaWorker(
+      UserConfig userConfig,
+      KafkaConsumer<String, V> consumer,
+      BadRecordPolicy policy,
+      SourceMetrics metrics) {
     this.userConfig = userConfig;
     this.consumer = consumer;
+    this.policy = policy;
+    this.metrics = metrics;
   }
 
   @Override
@@ -76,11 +89,46 @@ public class KafkaWorker<V> implements Runnable {
     }
   }
 
+  /**
+   * Polls until the deadline is reached, skipping past any poison record when {@code onError: skip}
+   * permits it.
+   *
+   * <p>Kafka 4.0's {@code CompletedFetch} caches a poison record's exception and does not advance
+   * {@code nextFetchOffset}, so re-polling (or seeking back to the same offset) rethrows the cached
+   * exception without re-invoking the deserializer - only a {@code seek} past the record clears it.
+   * The good records preceding a poison record in the same fetch are returned by an earlier poll, so
+   * only the offending record is dropped.
+   */
   private void pollRecords(long timeoutMs) {
+    long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs);
+    while (true) {
+      try {
+        consumerRecordList =
+            collect(consumer.poll(Duration.ofMillis(remainingMillis(deadlineNanos))));
+        return;
+      } catch (RecordDeserializationException e) {
+        if (!policy.shouldSkip(
+            RecordLocation.of(e), Stage.DECODE, e.getCause(), () -> bufferBytes(e.valueBuffer()))) {
+          throw e;
+        }
+        // Advance exactly one past the bad record; this also discards the buffered fetch whose
+        // cached exception would otherwise be rethrown by every later poll.
+        consumer.seek(e.topicPartition(), e.offset() + 1);
+        if (remainingMillis(deadlineNanos) == 0) {
+          // Read deadline spent; the next read cycle resumes past the drops.
+          consumerRecordList = List.of();
+          return;
+        }
+      }
+    }
+  }
+
+  private List<ConsumerRecord<String, V>> collect(ConsumerRecords<String, V> consumerRecords) {
     List<ConsumerRecord<String, V>> polled = new ArrayList<>();
-    ConsumerRecords<String, V> consumerRecords = consumer.poll(Duration.ofMillis(timeoutMs));
     for (ConsumerRecord<String, V> consumerRecord : consumerRecords) {
       if (consumerRecord.value() == null) {
+        // A Kafka tombstone. Previously silent; now at least visible in metrics.
+        metrics.recordDropped(DropReason.NULL_VALUE);
         continue;
       }
       log.debug(
@@ -91,7 +139,22 @@ public class KafkaWorker<V> implements Runnable {
       polled.add(consumerRecord);
     }
     log.debug("number of messages polled: {}", polled.size());
-    consumerRecordList = polled;
+    return polled;
+  }
+
+  private static long remainingMillis(long deadlineNanos) {
+    return Math.max(0L, TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime()));
+  }
+
+  /** Copies a buffer's bytes without disturbing its position, for the (lazy) bad-record sink. */
+  private static byte[] bufferBytes(ByteBuffer buffer) {
+    if (buffer == null) {
+      return new byte[0];
+    }
+    ByteBuffer duplicate = buffer.duplicate();
+    byte[] bytes = new byte[duplicate.remaining()];
+    duplicate.get(bytes);
+    return bytes;
   }
 
   private void commitAsync() {

--- a/src/main/java/io/numaproj/kafka/consumer/KafkaWorker.java
+++ b/src/main/java/io/numaproj/kafka/consumer/KafkaWorker.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -151,15 +152,21 @@ public class KafkaWorker<V> implements Runnable {
     return partitions;
   }
 
-  /** Enqueues a request and blocks until the worker thread finishes processing it. */
+  /**
+   * Enqueues a request and blocks until the worker thread finishes processing it.
+   *
+   * @throws InterruptedException if the calling thread is genuinely interrupted while waiting
+   */
   private void await(OperationRequest request) throws InterruptedException {
     operationCompletion = new CompletableFuture<>();
     taskQueue.add(request);
     try {
       operationCompletion.get();
-    } catch (Exception e) {
-      Thread.currentThread().interrupt();
-      throw new InterruptedException(e.getMessage());
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      throw cause instanceof RuntimeException runtime
+          ? runtime
+          : new RuntimeException("Kafka " + request.type() + " operation failed", cause);
     }
   }
 

--- a/src/main/java/io/numaproj/kafka/consumer/ReadErrorReason.java
+++ b/src/main/java/io/numaproj/kafka/consumer/ReadErrorReason.java
@@ -1,5 +1,8 @@
 package io.numaproj.kafka.consumer;
 
+import io.numaproj.kafka.common.BadRecordException;
+import io.numaproj.kafka.format.FormatException;
+
 /**
  * The closed, low-cardinality classification of a read-path failure. Used as a metric label, not a
  * policy gate: {@code onError: skip} skips every read failure regardless of reason for now, and this
@@ -11,5 +14,23 @@ public enum ReadErrorReason {
   /** The record's own bytes are bad: bad envelope, AEAD tag failure, undecodable Avro/JSON. */
   BAD_DATA,
   /** Not positively attributable to the record - e.g. a key-management or registry outage. */
-  UNKNOWN
+  UNKNOWN;
+
+  /**
+   * Classifies a failure by walking its cause chain for a {@link BadRecordException} or {@link
+   * FormatException}.
+   *
+   * <p><b>Trap:</b> {@code RecordDeserializationException} extends Kafka's {@code
+   * SerializationException}, not {@code BadRecordException}. Callers at the decode stage must pass
+   * {@code getCause()}, never the wrapper itself, or every decode failure classifies as {@link
+   * #UNKNOWN}.
+   */
+  static ReadErrorReason of(Throwable failure) {
+    for (Throwable t = failure; t != null; t = t.getCause()) {
+      if (t instanceof BadRecordException || t instanceof FormatException) {
+        return BAD_DATA;
+      }
+    }
+    return UNKNOWN;
+  }
 }

--- a/src/main/java/io/numaproj/kafka/consumer/ReadErrorReason.java
+++ b/src/main/java/io/numaproj/kafka/consumer/ReadErrorReason.java
@@ -1,0 +1,15 @@
+package io.numaproj.kafka.consumer;
+
+/**
+ * The closed, low-cardinality classification of a read-path failure. Used as a metric label, not a
+ * policy gate: {@code onError: skip} skips every read failure regardless of reason for now, and this
+ * enum exists so the drop is at least measurable and attributable.
+ *
+ * <p>Public: referenced from {@link io.numaproj.kafka.metrics.SourceMetrics}.
+ */
+public enum ReadErrorReason {
+  /** The record's own bytes are bad: bad envelope, AEAD tag failure, undecodable Avro/JSON. */
+  BAD_DATA,
+  /** Not positively attributable to the record - e.g. a key-management or registry outage. */
+  UNKNOWN
+}

--- a/src/main/java/io/numaproj/kafka/consumer/RecordLocation.java
+++ b/src/main/java/io/numaproj/kafka/consumer/RecordLocation.java
@@ -1,0 +1,24 @@
+package io.numaproj.kafka.consumer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.errors.RecordDeserializationException;
+
+/**
+ * Identifies a record by coordinates only, so no {@code ConsumerRecord} - and no decrypted value -
+ * is ever rendered into a log.
+ */
+record RecordLocation(String topic, int partition, long offset) {
+
+  static RecordLocation of(ConsumerRecord<?, ?> record) {
+    return new RecordLocation(record.topic(), record.partition(), record.offset());
+  }
+
+  static RecordLocation of(RecordDeserializationException e) {
+    return new RecordLocation(e.topicPartition().topic(), e.topicPartition().partition(), e.offset());
+  }
+
+  @Override
+  public String toString() {
+    return "topic:" + topic + " partition:" + partition + " offset:" + offset;
+  }
+}

--- a/src/main/java/io/numaproj/kafka/consumer/Stage.java
+++ b/src/main/java/io/numaproj/kafka/consumer/Stage.java
@@ -1,0 +1,13 @@
+package io.numaproj.kafka.consumer;
+
+/**
+ * The read-path stage at which a record failure was detected. Also a metric label.
+ *
+ * <p>Public: referenced from {@link io.numaproj.kafka.metrics.SourceMetrics}.
+ */
+public enum Stage {
+  /** Deserialization (and, when enabled, decryption) inside {@code consumer.poll()}. */
+  DECODE,
+  /** Conversion from the deserialized Kafka value to the downstream payload. */
+  CONVERT
+}

--- a/src/main/java/io/numaproj/kafka/encryption/PayloadDecryptionException.java
+++ b/src/main/java/io/numaproj/kafka/encryption/PayloadDecryptionException.java
@@ -1,13 +1,19 @@
 package io.numaproj.kafka.encryption;
 
+import io.numaproj.kafka.common.BadRecordException;
+
 /**
  * Unrecoverable error while decrypting an envelope-encrypted Kafka value. Thrown by the codec, DEK
  * unwrapper, and decryptor; surfaces as a deserialization failure and drives the source's fail-fast
  * behavior.
  *
+ * <p>Extends {@link BadRecordException}: every condition that raises this exception (a malformed
+ * envelope, an unsupported {@code alg}, an AEAD authentication-tag failure, ciphertext wrapped under
+ * the wrong key) is attributable to the record's own bytes, not the environment.
+ *
  * <p>Messages must never contain the plaintext DEK or decrypted payload.
  */
-public class PayloadDecryptionException extends RuntimeException {
+public class PayloadDecryptionException extends BadRecordException {
 
   public PayloadDecryptionException(String message) {
     super(message);

--- a/src/main/java/io/numaproj/kafka/encryption/aws/KmsDekUnwrapper.java
+++ b/src/main/java/io/numaproj/kafka/encryption/aws/KmsDekUnwrapper.java
@@ -1,6 +1,7 @@
 package io.numaproj.kafka.encryption.aws;
 
 import io.numaproj.kafka.encryption.DekUnwrapper;
+import io.numaproj.kafka.encryption.PayloadDecryptionException;
 import lombok.extern.slf4j.Slf4j;
 import software.amazon.awssdk.arns.Arn;
 import software.amazon.awssdk.core.SdkBytes;
@@ -9,6 +10,8 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.IncorrectKeyException;
+import software.amazon.awssdk.services.kms.model.InvalidCiphertextException;
 
 /**
  * {@link DekUnwrapper} backed by AWS KMS. Unwraps the DEK via {@code kms:Decrypt} with the
@@ -79,13 +82,21 @@ public class KmsDekUnwrapper implements DekUnwrapper {
 
   @Override
   public byte[] unwrap(byte[] wrappedDek) {
-    DecryptResponse response =
-        this.kms.decrypt(
-            DecryptRequest.builder()
-                .keyId(this.keyArn)
-                .ciphertextBlob(SdkBytes.fromByteArray(wrappedDek))
-                .build());
-    return response.plaintext().asByteArray();
+    try {
+      DecryptResponse response =
+          this.kms.decrypt(
+              DecryptRequest.builder()
+                  .keyId(this.keyArn)
+                  .ciphertextBlob(SdkBytes.fromByteArray(wrappedDek))
+                  .build());
+      return response.plaintext().asByteArray();
+    } catch (InvalidCiphertextException | IncorrectKeyException e) {
+      // Record-attributable: the wrapped DEK is corrupt, or was wrapped under a different key.
+      // Deliberately not translating ThrottlingException, AccessDeniedException,
+      // ExpiredTokenException, KmsInternalException or SdkClientException - those are environment
+      // failures, not the record's fault, and must classify as UNKNOWN.
+      throw new PayloadDecryptionException("Failed to unwrap the DEK via AWS KMS", e);
+    }
   }
 
   @Override

--- a/src/main/java/io/numaproj/kafka/format/AvroFormat.java
+++ b/src/main/java/io/numaproj/kafka/format/AvroFormat.java
@@ -56,7 +56,10 @@ public class AvroFormat implements KafkaFormat<GenericRecord> {
       writer.write(value, encoder);
       encoder.flush();
       return out.toByteArray();
-    } catch (IOException e) {
+    } catch (IOException | RuntimeException e) {
+      // The realistic malformed-Avro failure (e.g. AvroTypeException) is a RuntimeException, not
+      // an IOException - without this, it would bypass FormatException entirely, kill the pod
+      // regardless of onError, and make stage=convert unreachable.
       throw new FormatException("Failed to convert the Avro record to JSON format", e);
     }
   }

--- a/src/main/java/io/numaproj/kafka/metrics/MetricsServer.java
+++ b/src/main/java/io/numaproj/kafka/metrics/MetricsServer.java
@@ -1,0 +1,64 @@
+package io.numaproj.kafka.metrics;
+
+import io.prometheus.metrics.exporter.httpserver.HTTPServer;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Owns the lifecycle of the Prometheus HTTP scrape endpoint.
+ *
+ * <p>Default port is {@code 9091}, chosen to avoid Numaflow's reserved {@code 2469} (metrics),
+ * {@code 2470} (runtime) and {@code 4327} ports. Overridable via the {@code KAFKA_JAVA_METRICS_PORT}
+ * environment variable, and disabled entirely when that variable is set to {@code 0} - matching the
+ * existing {@code ROOT_LOG_LEVEL} / {@code KAFKA_LOG_LEVEL} env-var convention.
+ */
+@Slf4j
+public class MetricsServer {
+
+  public static final int DEFAULT_PORT = 9091;
+  private static final String PORT_ENV_VAR = "KAFKA_JAVA_METRICS_PORT";
+
+  private final HTTPServer httpServer;
+
+  private MetricsServer(HTTPServer httpServer) {
+    this.httpServer = httpServer;
+  }
+
+  /**
+   * Starts the metrics HTTP server against the given registry, unless disabled via {@code
+   * KAFKA_JAVA_METRICS_PORT=0}.
+   *
+   * @return the running server, or {@code null} if metrics serving is disabled
+   */
+  public static MetricsServer start(PrometheusRegistry registry) throws IOException {
+    int port = resolvePort();
+    if (port == 0) {
+      log.info("Metrics server disabled ({}=0)", PORT_ENV_VAR);
+      return null;
+    }
+    HTTPServer server =
+        HTTPServer.builder().port(port).registry(registry).buildAndStart();
+    log.info("Metrics server listening on port {} (path /metrics)", port);
+    return new MetricsServer(server);
+  }
+
+  private static int resolvePort() {
+    String override = System.getenv(PORT_ENV_VAR);
+    if (override == null || override.isBlank()) {
+      return DEFAULT_PORT;
+    }
+    try {
+      return Integer.parseInt(override.trim());
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          PORT_ENV_VAR + " must be an integer, got: " + override, e);
+    }
+  }
+
+  /** Stops the metrics server, releasing its port. Safe to call more than once. */
+  public void stop() {
+    log.info("Stopping metrics server");
+    httpServer.close();
+  }
+}

--- a/src/main/java/io/numaproj/kafka/metrics/PrometheusSourceMetrics.java
+++ b/src/main/java/io/numaproj/kafka/metrics/PrometheusSourceMetrics.java
@@ -1,0 +1,51 @@
+package io.numaproj.kafka.metrics;
+
+import io.numaproj.kafka.consumer.ReadErrorReason;
+import io.numaproj.kafka.consumer.Stage;
+import io.prometheus.metrics.core.metrics.Counter;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import java.util.Locale;
+
+/**
+ * {@link SourceMetrics} backed by the Prometheus Java client. The only class in this codebase that
+ * imports {@code io.prometheus} - every other class talks to the vendor-neutral {@link
+ * SourceMetrics} interface.
+ *
+ * <p>Metric names follow the {@code kafka_java_} prefix convention
+ * (numaproj-contrib/kafka-java#37). All label values come from closed enums, mapped to lowercase
+ * strings, so cardinality is bounded at compile time.
+ */
+public class PrometheusSourceMetrics implements SourceMetrics {
+
+  private final Counter readErrorsTotal;
+  private final Counter recordsDroppedTotal;
+
+  public PrometheusSourceMetrics(PrometheusRegistry registry) {
+    this.readErrorsTotal =
+        Counter.builder()
+            .name("kafka_java_source_read_errors_total")
+            .help("Read failures encountered while polling or converting a Kafka record.")
+            .labelNames("stage", "reason", "action")
+            .register(registry);
+    this.recordsDroppedTotal =
+        Counter.builder()
+            .name("kafka_java_source_records_dropped_total")
+            .help("Records dropped without being an error (e.g. Kafka tombstones).")
+            .labelNames("reason")
+            .register(registry);
+  }
+
+  @Override
+  public void recordReadError(Stage stage, ReadErrorReason reason, Action action) {
+    readErrorsTotal.labelValues(label(stage), label(reason), label(action)).inc();
+  }
+
+  @Override
+  public void recordDropped(DropReason reason) {
+    recordsDroppedTotal.labelValues(label(reason)).inc();
+  }
+
+  private static String label(Enum<?> value) {
+    return value.name().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/io/numaproj/kafka/metrics/SourceMetrics.java
+++ b/src/main/java/io/numaproj/kafka/metrics/SourceMetrics.java
@@ -1,0 +1,44 @@
+package io.numaproj.kafka.metrics;
+
+import io.numaproj.kafka.consumer.ReadErrorReason;
+import io.numaproj.kafka.consumer.Stage;
+
+/**
+ * Source-side counters. Vendor-neutral by design: no Prometheus/OTel/cloud types appear in any
+ * method signature, so this interface can be implemented by any metrics backend (or none, via
+ * {@link #NOOP}) without leaking a dependency into the read path.
+ */
+public interface SourceMetrics {
+
+  /** Whether a read failure at {@code stage} was skipped (dropped) or allowed to fail the pod. */
+  enum Action {
+    SKIPPED,
+    FAILED
+  }
+
+  /** Why a record was dropped without being counted as an error. */
+  enum DropReason {
+    /** A Kafka tombstone (null value). */
+    NULL_VALUE
+  }
+
+  /** Counts a read failure at the given stage, classified by reason, and by the action taken. */
+  void recordReadError(Stage stage, ReadErrorReason reason, Action action);
+
+  /** Counts a record dropped for a reason other than an error (e.g. a tombstone). */
+  void recordDropped(DropReason reason);
+
+  /** No-op implementation, used by tests and wherever metrics are not wired in (e.g. producer). */
+  SourceMetrics NOOP =
+      new SourceMetrics() {
+        @Override
+        public void recordReadError(Stage stage, ReadErrorReason reason, Action action) {
+          // no-op
+        }
+
+        @Override
+        public void recordDropped(DropReason reason) {
+          // no-op
+        }
+      };
+}

--- a/src/test/java/io/numaproj/kafka/config/ConsumerConfigTest.java
+++ b/src/test/java/io/numaproj/kafka/config/ConsumerConfigTest.java
@@ -1,19 +1,25 @@
 package io.numaproj.kafka.config;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
+import com.amazonaws.services.schemaregistry.exception.AWSSchemaRegistryException;
+import com.amazonaws.services.schemaregistry.exception.GlueSchemaRegistryIncompatibleDataException;
+import io.numaproj.kafka.common.BadRecordException;
 import io.numaproj.kafka.encryption.DecryptingDeserializer;
 import io.numaproj.kafka.encryption.EnvelopeDecryptionFactory;
 import io.numaproj.kafka.encryption.PayloadDecryptor;
 import java.util.Objects;
 import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.services.kms.model.KmsInternalException;
 
 @Slf4j
 @ExtendWith(MockitoExtension.class)
@@ -170,5 +176,52 @@ public class ConsumerConfigTest {
         ConsumerConfig.wrapWithDecryption(new StringDeserializer(), decryptor);
     assertInstanceOf(DecryptingDeserializer.class, wrapped);
     wrapped.close(); // releases the KMS client held by the decryptor
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Deserializer<Object> mockDeserializer() {
+    return mock(Deserializer.class);
+  }
+
+  @Test
+  public void wrapWithBadRecordTranslation_glueIncompatibleData_translatesToBadRecordException() {
+    Deserializer<Object> delegate = mockDeserializer();
+    when(delegate.deserialize(any(), any()))
+        .thenThrow(new GlueSchemaRegistryIncompatibleDataException("bad header byte"));
+    Deserializer<Object> wrapped = ConsumerConfig.wrapWithBadRecordTranslation(delegate);
+
+    assertThrows(BadRecordException.class, () -> wrapped.deserialize("topic", new byte[0]));
+  }
+
+  @Test
+  public void wrapWithBadRecordTranslation_glueApiFailure_propagatesUntranslated() {
+    Deserializer<Object> delegate = mockDeserializer();
+    when(delegate.deserialize(any(), any()))
+        .thenThrow(
+            new AWSSchemaRegistryException(
+                "registry unreachable",
+                KmsInternalException.builder().message("slow").build()));
+    Deserializer<Object> wrapped = ConsumerConfig.wrapWithBadRecordTranslation(delegate);
+
+    assertThrows(AWSSchemaRegistryException.class, () -> wrapped.deserialize("topic", new byte[0]));
+  }
+
+  @Test
+  public void wrapWithBadRecordTranslation_glueExceptionWithNoSdkCause_translatesToBadRecordException() {
+    Deserializer<Object> delegate = mockDeserializer();
+    when(delegate.deserialize(any(), any()))
+        .thenThrow(new AWSSchemaRegistryException("some other schema registry failure"));
+    Deserializer<Object> wrapped = ConsumerConfig.wrapWithBadRecordTranslation(delegate);
+
+    assertThrows(BadRecordException.class, () -> wrapped.deserialize("topic", new byte[0]));
+  }
+
+  @Test
+  public void wrapWithBadRecordTranslation_serializationException_translatesToBadRecordException() {
+    Deserializer<Object> delegate = mockDeserializer();
+    when(delegate.deserialize(any(), any())).thenThrow(new SerializationException("malformed"));
+    Deserializer<Object> wrapped = ConsumerConfig.wrapWithBadRecordTranslation(delegate);
+
+    assertThrows(BadRecordException.class, () -> wrapped.deserialize("topic", new byte[0]));
   }
 }

--- a/src/test/java/io/numaproj/kafka/config/OnErrorTest.java
+++ b/src/test/java/io/numaproj/kafka/config/OnErrorTest.java
@@ -1,0 +1,40 @@
+package io.numaproj.kafka.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class OnErrorTest {
+
+  @Test
+  void from_null_returnsFail() {
+    assertEquals(OnError.FAIL, OnError.from(null));
+  }
+
+  @Test
+  void from_blank_returnsFail() {
+    assertEquals(OnError.FAIL, OnError.from("  "));
+  }
+
+  @Test
+  void from_isCaseInsensitive() {
+    assertEquals(OnError.FAIL, OnError.from("fail"));
+    assertEquals(OnError.FAIL, OnError.from("Fail"));
+    assertEquals(OnError.FAIL, OnError.from("FAIL"));
+    assertEquals(OnError.SKIP, OnError.from("skip"));
+    assertEquals(OnError.SKIP, OnError.from("Skip"));
+    assertEquals(OnError.SKIP, OnError.from("SKIP"));
+  }
+
+  @Test
+  void from_trimsWhitespace() {
+    assertEquals(OnError.SKIP, OnError.from("  skip  "));
+  }
+
+  @Test
+  void from_unknownValue_throwsIllegalArgumentException() {
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> OnError.from("dead-letter"));
+    assertTrue(e.getMessage().contains("dead-letter"));
+  }
+}

--- a/src/test/java/io/numaproj/kafka/consumer/BadRecordPolicyTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/BadRecordPolicyTest.java
@@ -1,0 +1,63 @@
+package io.numaproj.kafka.consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import io.numaproj.kafka.common.BadRecordException;
+import io.numaproj.kafka.config.OnError;
+import io.numaproj.kafka.metrics.SourceMetrics;
+import io.numaproj.kafka.metrics.SourceMetrics.Action;
+import org.junit.jupiter.api.Test;
+
+class BadRecordPolicyTest {
+
+  private static final RecordLocation LOCATION = RecordLocation.of(sampleRecord());
+
+  private final SourceMetrics metrics = mock(SourceMetrics.class);
+  private final BadRecordSink sink = mock(BadRecordSink.class);
+
+  private static org.apache.kafka.clients.consumer.ConsumerRecord<String, byte[]> sampleRecord() {
+    return new org.apache.kafka.clients.consumer.ConsumerRecord<>(
+        "t", 0, 5L, "key", "value".getBytes());
+  }
+
+  @Test
+  void shouldSkip_onErrorFail_neverSkipsAndCountsFailed() {
+    BadRecordPolicy policy = new BadRecordPolicy(OnError.FAIL, metrics, sink);
+    BadRecordException failure = new BadRecordException("bad");
+
+    boolean skipped = policy.shouldSkip(LOCATION, Stage.DECODE, failure, () -> new byte[0]);
+
+    assertFalse(skipped);
+    verify(metrics).recordReadError(Stage.DECODE, ReadErrorReason.BAD_DATA, Action.FAILED);
+    verify(sink, never()).quarantine(any());
+  }
+
+  @Test
+  void shouldSkip_onErrorSkip_skipsAndReachesSinkWithCorrectStageAndReason() {
+    BadRecordPolicy policy = new BadRecordPolicy(OnError.SKIP, metrics, sink);
+    RuntimeException failure = new RuntimeException("environmental");
+
+    boolean skipped = policy.shouldSkip(LOCATION, Stage.CONVERT, failure, () -> new byte[0]);
+
+    assertTrue(skipped);
+    verify(metrics).recordReadError(Stage.CONVERT, ReadErrorReason.UNKNOWN, Action.SKIPPED);
+    verify(sink)
+        .quarantine(
+            argThat(
+                badRecord ->
+                    badRecord.location().equals(LOCATION)
+                        && badRecord.stage() == Stage.CONVERT
+                        && badRecord.reason() == ReadErrorReason.UNKNOWN
+                        && badRecord.failure() == failure));
+  }
+
+  @Test
+  void shouldSkip_onErrorFail_refusalNeverReachesSink() {
+    BadRecordPolicy policy = new BadRecordPolicy(OnError.FAIL, metrics, sink);
+
+    policy.shouldSkip(LOCATION, Stage.DECODE, new BadRecordException("bad"), () -> new byte[0]);
+
+    verifyNoInteractions(sink);
+  }
+}

--- a/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import io.numaproj.kafka.format.ByteArrayFormat;
+import io.numaproj.kafka.format.FormatException;
+import io.numaproj.kafka.format.KafkaFormat;
 import io.numaproj.numaflow.sourcer.*;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -81,6 +83,36 @@ class KafkaSourcerTest {
     doNothing().when(underTest).kill(any());
     underTest.read(readRequest(1), observer);
     verify(underTest).kill(any(RuntimeException.class));
+  }
+
+  @Test
+  void read_whenFormatFails_thenFailureMessageIdentifiesRecordByCoordinatesOnly()
+      throws Exception {
+    KafkaSourcer<byte[]> sourcer =
+        Mockito.spy(new KafkaSourcer<>(null, admin, failingFormat(), batchSize -> null));
+    Thread aliveThread = mock(Thread.class);
+    when(aliveThread.isAlive()).thenReturn(true);
+    sourcer.setWorker(worker, aliveThread);
+    ConsumerRecord<String, byte[]> sensitiveRecord =
+        new ConsumerRecord<>(TOPIC, 1, 42L, "key", "super-secret-value".getBytes());
+    when(worker.poll(anyLong())).thenReturn(List.of(sensitiveRecord));
+
+    RuntimeException thrown =
+        assertThrows(RuntimeException.class, () -> sourcer.read(readRequest(1), observer));
+
+    assertTrue(thrown.getMessage().contains("offset:42"));
+    assertFalse(thrown.getMessage().contains("ConsumerRecord"));
+    assertFalse(thrown.getMessage().contains("super-secret-value"));
+  }
+
+  private static KafkaFormat<byte[]> failingFormat() {
+    KafkaFormat<byte[]> format = mock(KafkaFormat.class);
+    try {
+      when(format.toPayload(any())).thenThrow(new FormatException("boom"));
+    } catch (FormatException e) {
+      throw new RuntimeException(e);
+    }
+    return format;
   }
 
   @Test

--- a/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
@@ -3,6 +3,8 @@ package io.numaproj.kafka.consumer;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.numaproj.kafka.config.OnError;
+import io.numaproj.kafka.config.UserConfig;
 import io.numaproj.kafka.format.ByteArrayFormat;
 import io.numaproj.kafka.format.FormatException;
 import io.numaproj.kafka.format.KafkaFormat;
@@ -14,6 +16,7 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class KafkaSourcerTest {
@@ -29,11 +32,28 @@ class KafkaSourcerTest {
 
   @BeforeEach
   void setUp() {
-    underTest =
-        Mockito.spy(new KafkaSourcer<>(null, admin, new ByteArrayFormat(), batchSize -> null));
+    underTest = sourcer(new ByteArrayFormat(), OnError.FAIL, worker);
+  }
+
+  /**
+   * A mocked UserConfig, per the plan: {@code null} is not tolerated (the constructor calls {@code
+   * userConfig.getOnError()}), but a Mockito mock returning {@code null} for an unstubbed {@code
+   * getOnError()} is, since every call site is null-tolerant (compares {@code == OnError.SKIP}).
+   */
+  private static UserConfig userConfig(OnError onError) {
+    UserConfig userConfig = mock(UserConfig.class);
+    when(userConfig.getOnError()).thenReturn(onError);
+    return userConfig;
+  }
+
+  private KafkaSourcer<byte[]> sourcer(
+      KafkaFormat<byte[]> format, OnError onError, KafkaWorker<byte[]> worker) {
+    KafkaSourcer<byte[]> sourcer =
+        Mockito.spy(new KafkaSourcer<>(userConfig(onError), admin, format, batchSize -> null));
     Thread aliveThread = mock(Thread.class);
     when(aliveThread.isAlive()).thenReturn(true);
-    underTest.setWorker(worker, aliveThread);
+    sourcer.setWorker(worker, aliveThread);
+    return sourcer;
   }
 
   private static ReadRequest readRequest(long count) {
@@ -86,25 +106,38 @@ class KafkaSourcerTest {
   }
 
   @Test
-  void read_whenFormatFails_thenFailureMessageIdentifiesRecordByCoordinatesOnly()
+  void read_whenFormatFailsAndOnErrorFail_thenKillsWithFailureIdentifyingRecordByCoordinatesOnly()
       throws Exception {
-    KafkaSourcer<byte[]> sourcer =
-        Mockito.spy(new KafkaSourcer<>(null, admin, failingFormat(), batchSize -> null));
-    Thread aliveThread = mock(Thread.class);
-    when(aliveThread.isAlive()).thenReturn(true);
-    sourcer.setWorker(worker, aliveThread);
+    KafkaSourcer<byte[]> sourcer = sourcer(failingFormat(), OnError.FAIL, worker);
     ConsumerRecord<String, byte[]> sensitiveRecord =
         new ConsumerRecord<>(TOPIC, 1, 42L, "key", "super-secret-value".getBytes());
     when(worker.poll(anyLong())).thenReturn(List.of(sensitiveRecord));
+    doNothing().when(sourcer).kill(any());
 
-    RuntimeException thrown =
-        assertThrows(RuntimeException.class, () -> sourcer.read(readRequest(1), observer));
+    sourcer.read(readRequest(1), observer);
 
-    assertTrue(thrown.getMessage().contains("offset:42"));
-    assertFalse(thrown.getMessage().contains("ConsumerRecord"));
-    assertFalse(thrown.getMessage().contains("super-secret-value"));
+    verify(observer, never()).send(any());
+    ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+    verify(sourcer).kill(captor.capture());
+    String message = captor.getValue().getMessage();
+    assertTrue(message.contains("offset:42"));
+    assertFalse(message.contains("ConsumerRecord"));
+    assertFalse(message.contains("super-secret-value"));
   }
 
+  @Test
+  void read_whenFormatFailsAndOnErrorSkip_thenDropsWithoutSendingOrKilling() throws Exception {
+    KafkaSourcer<byte[]> sourcer = sourcer(failingFormat(), OnError.SKIP, worker);
+    when(worker.poll(anyLong())).thenReturn(List.of(record(7)));
+    doNothing().when(sourcer).kill(any());
+
+    sourcer.read(readRequest(1), observer);
+
+    verify(observer, never()).send(any());
+    verify(sourcer, never()).kill(any());
+  }
+
+  @SuppressWarnings("unchecked")
   private static KafkaFormat<byte[]> failingFormat() {
     KafkaFormat<byte[]> format = mock(KafkaFormat.class);
     try {

--- a/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/KafkaSourcerTest.java
@@ -84,6 +84,14 @@ class KafkaSourcerTest {
   }
 
   @Test
+  void read_whenPollThrowsRuntimeException_thenKills() throws Exception {
+    when(worker.poll(anyLong())).thenThrow(new RuntimeException("boom"));
+    doNothing().when(underTest).kill(any());
+    underTest.read(readRequest(1), observer);
+    verify(underTest).kill(any(RuntimeException.class));
+  }
+
+  @Test
   void read_whenWorkerThreadDead_thenKills() {
     Thread deadThread = mock(Thread.class);
     when(deadThread.isAlive()).thenReturn(false);

--- a/src/test/java/io/numaproj/kafka/consumer/KafkaWorkerTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/KafkaWorkerTest.java
@@ -51,6 +51,19 @@ class KafkaWorkerTest {
   }
 
   @Test
+  void poll_whenConsumerThrows_thenPropagatesOriginalCauseAndLeavesInterruptFlagClear()
+      throws Exception {
+    RuntimeException boom = new RuntimeException("boom");
+    when(consumer.poll(any())).thenThrow(boom);
+    thread.start();
+
+    RuntimeException thrown = assertThrows(RuntimeException.class, () -> worker.poll(1000));
+
+    assertSame(boom, thrown);
+    assertFalse(Thread.currentThread().isInterrupted());
+  }
+
+  @Test
   void commit_delegatesToConsumer() throws Exception {
     thread.start();
     worker.commit();

--- a/src/test/java/io/numaproj/kafka/consumer/KafkaWorkerTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/KafkaWorkerTest.java
@@ -3,13 +3,17 @@ package io.numaproj.kafka.consumer;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import io.numaproj.kafka.config.OnError;
 import io.numaproj.kafka.config.UserConfig;
+import io.numaproj.kafka.metrics.SourceMetrics;
+import java.nio.ByteBuffer;
 import java.util.*;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.AfterEach;
@@ -24,6 +28,8 @@ class KafkaWorkerTest {
   @SuppressWarnings("unchecked")
   private final KafkaConsumer<String, byte[]> consumer = mock(KafkaConsumer.class);
 
+  private final SourceMetrics metrics = mock(SourceMetrics.class);
+
   private KafkaWorker<byte[]> worker;
   private Thread thread;
 
@@ -31,8 +37,35 @@ class KafkaWorkerTest {
   void setUp() {
     UserConfig userConfig = mock(UserConfig.class);
     when(userConfig.getTopicName()).thenReturn(TOPIC);
-    worker = new KafkaWorker<>(userConfig, consumer);
+    worker = newWorker(OnError.FAIL);
     thread = new Thread(worker);
+  }
+
+  private KafkaWorker<byte[]> newWorker(OnError onError) {
+    BadRecordPolicy policy = new BadRecordPolicy(onError, metrics, mock(BadRecordSink.class));
+    return new KafkaWorker<>(mockUserConfig(), consumer, policy, metrics);
+  }
+
+  private static UserConfig mockUserConfig() {
+    UserConfig userConfig = mock(UserConfig.class);
+    when(userConfig.getTopicName()).thenReturn(TOPIC);
+    return userConfig;
+  }
+
+  /** Not the {@code @Deprecated} 4-arg constructor - see KafkaWorker's pollRecords javadoc. */
+  private static RecordDeserializationException deserializationException(
+      long offset, Throwable cause) {
+    return new RecordDeserializationException(
+        RecordDeserializationException.DeserializationExceptionOrigin.VALUE,
+        new TopicPartition(TOPIC, 1),
+        offset,
+        0L,
+        TimestampType.CREATE_TIME,
+        ByteBuffer.allocate(0),
+        ByteBuffer.allocate(0),
+        new RecordHeaders(),
+        "boom",
+        cause);
   }
 
   @AfterEach
@@ -61,6 +94,36 @@ class KafkaWorkerTest {
 
     assertSame(boom, thrown);
     assertFalse(Thread.currentThread().isInterrupted());
+  }
+
+  @Test
+  void poll_onErrorFail_propagatesDeserializationExceptionAndNeverSeeks() throws Exception {
+    RecordDeserializationException deserializationException =
+        deserializationException(5L, new RuntimeException("bad avro"));
+    when(consumer.poll(any())).thenThrow(deserializationException);
+    thread.start();
+
+    RecordDeserializationException thrown =
+        assertThrows(RecordDeserializationException.class, () -> worker.poll(1000));
+
+    assertSame(deserializationException, thrown);
+    verify(consumer, never()).seek(any(), anyLong());
+  }
+
+  @Test
+  void poll_onErrorSkip_seeksPastBadRecordAndStopsRetryingOnceDeadlineElapses() throws Exception {
+    worker = newWorker(OnError.SKIP);
+    thread = new Thread(worker);
+    RecordDeserializationException deserializationException =
+        deserializationException(5L, new RuntimeException("bad avro"));
+    when(consumer.poll(any())).thenThrow(deserializationException);
+    thread.start();
+
+    List<ConsumerRecord<String, byte[]>> got = worker.poll(0);
+
+    assertEquals(List.of(), got);
+    verify(consumer, times(1)).poll(any());
+    verify(consumer, times(1)).seek(new TopicPartition(TOPIC, 1), 6L);
   }
 
   @Test

--- a/src/test/java/io/numaproj/kafka/consumer/LoggingBadRecordSinkTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/LoggingBadRecordSinkTest.java
@@ -1,0 +1,30 @@
+package io.numaproj.kafka.consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+class LoggingBadRecordSinkTest {
+
+  @Test
+  void quarantine_neverInvokesRawValueSupplier() {
+    ConsumerRecord<String, byte[]> record =
+        new ConsumerRecord<>("t", 0, 5L, "key", "value".getBytes());
+    boolean[] invoked = {false};
+    BadRecord badRecord =
+        new BadRecord(
+            RecordLocation.of(record),
+            Stage.DECODE,
+            ReadErrorReason.BAD_DATA,
+            new RuntimeException("boom"),
+            () -> {
+              invoked[0] = true;
+              return "super-secret-decrypted-payload".getBytes();
+            });
+
+    new LoggingBadRecordSink().quarantine(badRecord);
+
+    assertFalse(invoked[0], "the raw payload supplier must never be evaluated by a logging sink");
+  }
+}

--- a/src/test/java/io/numaproj/kafka/consumer/ReadErrorReasonTest.java
+++ b/src/test/java/io/numaproj/kafka/consumer/ReadErrorReasonTest.java
@@ -1,0 +1,65 @@
+package io.numaproj.kafka.consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.numaproj.kafka.common.BadRecordException;
+import io.numaproj.kafka.encryption.PayloadDecryptionException;
+import io.numaproj.kafka.format.FormatException;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RecordDeserializationException;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.exception.SdkException;
+
+class ReadErrorReasonTest {
+
+  @Test
+  void of_payloadDecryptionException_isBadData() {
+    assertEquals(
+        ReadErrorReason.BAD_DATA,
+        ReadErrorReason.of(new PayloadDecryptionException("bad envelope")));
+  }
+
+  @Test
+  void of_formatException_isBadData() {
+    assertEquals(ReadErrorReason.BAD_DATA, ReadErrorReason.of(new FormatException("bad avro")));
+  }
+
+  @Test
+  void of_badRecordExceptionNestedBehindDeserializationWrapper_isBadData() {
+    RecordDeserializationException wrapper =
+        new RecordDeserializationException(
+            RecordDeserializationException.DeserializationExceptionOrigin.VALUE,
+            new TopicPartition("t", 0),
+            1L,
+            0L,
+            TimestampType.CREATE_TIME,
+            ByteBuffer.allocate(0),
+            ByteBuffer.allocate(0),
+            new RecordHeaders(),
+            "boom",
+            new BadRecordException("malformed"));
+
+    // Classification reads the cause chain, not the RecordDeserializationException wrapper.
+    assertEquals(ReadErrorReason.BAD_DATA, ReadErrorReason.of(wrapper.getCause()));
+  }
+
+  @Test
+  void of_bareRuntimeException_isUnknown() {
+    assertEquals(ReadErrorReason.UNKNOWN, ReadErrorReason.of(new RuntimeException("boom")));
+  }
+
+  @Test
+  void of_ioException_isUnknown() {
+    assertEquals(ReadErrorReason.UNKNOWN, ReadErrorReason.of(new IOException("boom")));
+  }
+
+  @Test
+  void of_untranslatedSdkException_isUnknown() {
+    assertEquals(
+        ReadErrorReason.UNKNOWN, ReadErrorReason.of(SdkException.create("slow down", null)));
+  }
+}

--- a/src/test/java/io/numaproj/kafka/encryption/aws/KmsDekUnwrapperTest.java
+++ b/src/test/java/io/numaproj/kafka/encryption/aws/KmsDekUnwrapperTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.numaproj.kafka.encryption.PayloadDecryptionException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -20,7 +21,10 @@ import software.amazon.awssdk.core.SdkBytes;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.DecryptRequest;
 import software.amazon.awssdk.services.kms.model.DecryptResponse;
+import software.amazon.awssdk.services.kms.model.IncorrectKeyException;
+import software.amazon.awssdk.services.kms.model.InvalidCiphertextException;
 import software.amazon.awssdk.services.kms.model.KmsException;
+import software.amazon.awssdk.services.kms.model.KmsInternalException;
 
 @ExtendWith(MockitoExtension.class)
 class KmsDekUnwrapperTest {
@@ -55,6 +59,30 @@ class KmsDekUnwrapperTest {
         .thenThrow(KmsException.builder().message("access denied").build());
 
     assertThrows(KmsException.class, () -> unwrapper().unwrap(WRAPPED));
+  }
+
+  @Test
+  void translatesInvalidCiphertextToPayloadDecryptionException() {
+    when(kms.decrypt(any(DecryptRequest.class)))
+        .thenThrow(InvalidCiphertextException.builder().message("corrupt").build());
+
+    assertThrows(PayloadDecryptionException.class, () -> unwrapper().unwrap(WRAPPED));
+  }
+
+  @Test
+  void translatesIncorrectKeyToPayloadDecryptionException() {
+    when(kms.decrypt(any(DecryptRequest.class)))
+        .thenThrow(IncorrectKeyException.builder().message("wrong key").build());
+
+    assertThrows(PayloadDecryptionException.class, () -> unwrapper().unwrap(WRAPPED));
+  }
+
+  @Test
+  void propagatesKmsInternalExceptionUntranslated() {
+    when(kms.decrypt(any(DecryptRequest.class)))
+        .thenThrow(KmsInternalException.builder().message("internal error").build());
+
+    assertThrows(KmsInternalException.class, () -> unwrapper().unwrap(WRAPPED));
   }
 
   @Test

--- a/src/test/java/io/numaproj/kafka/format/AvroFormatTest.java
+++ b/src/test/java/io/numaproj/kafka/format/AvroFormatTest.java
@@ -35,6 +35,19 @@ class AvroFormatTest {
   }
 
   @Test
+  void toPayload_typeMismatch_throwsFormatExceptionNotRawRuntimeException() {
+    // The realistic malformed-Avro failure (e.g. AvroTypeException) is a RuntimeException, not an
+    // IOException. Without catching RuntimeException too, it bypasses FormatException entirely,
+    // killing the pod regardless of onError and making stage=convert unreachable.
+    GenericRecord record = new GenericData.Record(SCHEMA);
+    record.put("name", 12345); // schema declares "name" as a string
+
+    FormatException e =
+        assertThrows(FormatException.class, () -> AvroFormat.forSource().toPayload(record));
+    assertInstanceOf(RuntimeException.class, e.getCause());
+  }
+
+  @Test
   void forSink_nullSchema_rejected() {
     assertThrows(IllegalArgumentException.class, () -> AvroFormat.forSink(null));
   }

--- a/src/test/java/io/numaproj/kafka/metrics/PrometheusSourceMetricsTest.java
+++ b/src/test/java/io/numaproj/kafka/metrics/PrometheusSourceMetricsTest.java
@@ -1,0 +1,56 @@
+package io.numaproj.kafka.metrics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.numaproj.kafka.consumer.ReadErrorReason;
+import io.numaproj.kafka.consumer.Stage;
+import io.numaproj.kafka.metrics.SourceMetrics.Action;
+import io.numaproj.kafka.metrics.SourceMetrics.DropReason;
+import io.prometheus.metrics.expositionformats.PrometheusTextFormatWriter;
+import io.prometheus.metrics.model.registry.PrometheusRegistry;
+import io.prometheus.metrics.model.snapshots.MetricSnapshots;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class PrometheusSourceMetricsTest {
+
+  private PrometheusRegistry registry;
+  private PrometheusSourceMetrics metrics;
+
+  @BeforeEach
+  void setUp() {
+    registry = new PrometheusRegistry();
+    metrics = new PrometheusSourceMetrics(registry);
+  }
+
+  @Test
+  void recordReadError_incrementsCounterWithLowercaseLabels() throws IOException {
+    metrics.recordReadError(Stage.DECODE, ReadErrorReason.BAD_DATA, Action.SKIPPED);
+
+    String scraped = scrape();
+
+    assertTrue(scraped.contains("kafka_java_source_read_errors_total"));
+    assertTrue(scraped.contains("stage=\"decode\""));
+    assertTrue(scraped.contains("reason=\"bad_data\""));
+    assertTrue(scraped.contains("action=\"skipped\""));
+  }
+
+  @Test
+  void recordDropped_incrementsCounterWithLowercaseLabel() throws IOException {
+    metrics.recordDropped(DropReason.NULL_VALUE);
+
+    String scraped = scrape();
+
+    assertTrue(scraped.contains("kafka_java_source_records_dropped_total"));
+    assertTrue(scraped.contains("reason=\"null_value\""));
+  }
+
+  private String scrape() throws IOException {
+    MetricSnapshots snapshots = registry.scrape();
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    new PrometheusTextFormatWriter(true).write(out, snapshots);
+    return out.toString();
+  }
+}


### PR DESCRIPTION
## Summary

Makes the Kafka **source** connector's response to unreadable records configurable, instead of always crash-looping the vertex, and makes every dropped record measurable via Prometheus so a skip is never silent.

Adds a `user.configuration` key `onError: fail|skip` (default `fail`, preserving current behaviour). With `onError: skip`, a record that cannot be decoded/decrypted or converted to a payload is dropped and counted rather than killing the pod.

## Changes

- **`fix(source): preserve the original failure when a Kafka worker operation fails`** — `KafkaWorker.await()` was swallowing the real cause and rethrowing a bare `InterruptedException`, so operators couldn't tell a corrupt record from an infrastructure failure (e.g. expired credentials). Now the original exception/cause propagates.
- **`fix(source): stop including the decrypted record in conversion failure messages`** — the existing conversion-failure log/error message rendered the full `ConsumerRecord`, which for the Avro path includes the **decrypted** payload via `GenericRecord.toString()`. Messages now identify a bad record by `topic:partition:offset` only.
- **`feat(metrics): expose Prometheus metrics over HTTP`** — adds a small vendor-neutral `SourceMetrics` interface with a single `io.prometheus`-importing implementation and an embedded HTTP exporter (JDK `HttpServer`, no extra transitives) on port `9091` (`/metrics`), configurable via `KAFKA_JAVA_METRICS_PORT` (`0` disables it). `numaflow-java` exposes no metrics API of its own, and Numaflow's user-defined `Container.ports` field exists specifically to support this.
- **`refactor(encryption): mark record-attributable failures with BadRecordException`** — introduces one marker exception, `BadRecordException`, meaning "this record's own bytes are the problem" (as opposed to an environmental failure like KMS throttling or a schema-registry outage). Glue/Confluent deserialization errors and payload-decryption errors that are the record's fault are mapped to it; provider-specific exception types stay confined to their adapters so the core read path remains cloud-agnostic.
- **`feat(source): add onError=skip to drop and count records that fail to be read`** — the headline feature. A single `BadRecordPolicy` decides skip-vs-fail and increments `kafka_java_source_read_errors_total{stage,reason,action}` for every read failure at both failure points (decode, during `consumer.poll`, and convert, in `KafkaFormat.toPayload`). `stage=decode` skips now seek past the offending offset within the read deadline instead of retrying unboundedly. Currently *all* read failures are skipped under `onError: skip` (including ones not attributable to the record's own bytes); `reason="unknown"` on the counter is the interim operator signal for that case, with a `TODO` marking the follow-up that adds proper retry/circuit-breaking for environmental failures.
- **`fix(format): treat any Avro-to-JSON encoding failure as a format error`** — `AvroFormat.toPayload` only caught `IOException`, so a malformed-Avro `RuntimeException` (e.g. `AvroTypeException`) bypassed `FormatException` entirely and killed the pod regardless of `onError`. Now any `RuntimeException` from the Avro→JSON conversion is treated as a format error, so `onError: skip` actually covers this path.
- **`docs(source): document the onError policy and the skip metrics`** — documents `onError` across all four source config manifests and their guides, adds `docs/metrics/source-metrics.md` (metric reference, PromQL, PodMonitor/annotation scraping — a `ServiceMonitor` cannot reach this port since the headless Service's ports are hardcoded), and links it from the README.

## Metrics

| Metric | Labels | Meaning |
|---|---|---|
| `kafka_java_source_read_errors_total` | `stage`=`decode`\|`convert`, `reason`=`bad_data`\|`unknown`, `action`=`skipped`\|`failed` | Every read failure, whether it killed the pod or was skipped. |
| `kafka_java_source_records_dropped_total` | `reason`=`null_value` | Non-error drops (tombstones) — previously silent. |

Suggested alert: `increase(kafka_java_source_read_errors_total{reason="unknown"}[5m]) > 0` — records were skipped for a reason not attributable to their own bytes, i.e. likely a live incident discarding good data.

## Testing

`mvn test` — 139 tests, all passing. Covers the new `BadRecordPolicy`/`ReadErrorReason`/`BadRecordSink` classes, the deadline-bounded seek-and-skip loop in `KafkaWorker`, the plaintext-leak regression (asserts the failure message never contains `ConsumerRecord`), the `AvroFormat` widening, and the Prometheus metrics registry contract.

## Out of scope (deferred)

- Properly handling environmental failures (retry/circuit-break) instead of skipping them like bad data — `reason="unknown"` is the interim signal.
- A dead-letter queue (`onError: dead-letter`) — `BadRecordSink` is the integration seam for it.
- Sink-side metrics (`KafkaSinker` has its own uncounted error paths).
